### PR TITLE
Add TypeScript compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 /lib/
 /service-worker/
 /shared/
+/typescript-worker/
 service-worker.js
+typescript-worker.js

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,6 +13,7 @@
 </head>
 
 <body>
+  <code-sample-editor project-src="./typescript/project.json"></code-sample-editor>
   <code-sample-editor project-src="./project-1/project.json"></code-sample-editor>
   <code-sample-editor project-src="./mwc-button/project.json"></code-sample-editor>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1437,17 +1437,34 @@
         "whatwg-url": "^7.0.0"
       }
     },
-    "@rollup/plugin-node-resolve": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
-      "integrity": "sha512-RxtSL3XmdTAE2byxekYLnx+98kEUOrPHF/KRVjLH+DEIHy6kjIw7YINQzn+NXiH/NTrQLAwYs0GWB+csWygA9Q==",
+    "@rollup/plugin-commonjs": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-14.0.0.tgz",
+      "integrity": "sha512-+PSmD9ePwTAeU106i9FRdc+Zb3XUWyW26mo5Atr2mk82hor8+nPwkztEjFo8/B1fJKfaQDg9aM2bzQkjhi7zOw==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.0.8",
-        "@types/resolve": "0.0.8",
+        "commondir": "^1.0.1",
+        "estree-walker": "^1.0.1",
+        "glob": "^7.1.2",
+        "is-reference": "^1.1.2",
+        "magic-string": "^0.25.2",
+        "resolve": "^1.11.0"
+      }
+    },
+    "@rollup/plugin-node-resolve": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-8.4.0.tgz",
+      "integrity": "sha512-LFqKdRLn0ShtQyf6SBYO69bGE1upV6wUhBX0vFOUnLAyzx5cwp8svA0eHUnu8+YU57XOkrMtfG63QOpQx25pHQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
         "builtin-modules": "^3.1.0",
+        "deep-freeze": "^0.0.1",
+        "deepmerge": "^4.2.2",
         "is-module": "^1.0.0",
-        "resolve": "^1.14.2"
+        "resolve": "^1.17.0"
       }
     },
     "@rollup/pluginutils": {
@@ -1756,9 +1773,9 @@
       "dev": true
     },
     "@types/resolve": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
-      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -2116,6 +2133,12 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
     "compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -2233,6 +2256,12 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
+    },
+    "deep-freeze": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
+      "integrity": "sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ=",
       "dev": true
     },
     "deepmerge": {
@@ -2397,6 +2426,30 @@
         "tslib": "^1.11.1",
         "useragent": "^2.3.0",
         "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "@rollup/plugin-node-resolve": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
+          "integrity": "sha512-RxtSL3XmdTAE2byxekYLnx+98kEUOrPHF/KRVjLH+DEIHy6kjIw7YINQzn+NXiH/NTrQLAwYs0GWB+csWygA9Q==",
+          "dev": true,
+          "requires": {
+            "@rollup/pluginutils": "^3.0.8",
+            "@types/resolve": "0.0.8",
+            "builtin-modules": "^3.1.0",
+            "is-module": "^1.0.0",
+            "resolve": "^1.14.2"
+          }
+        },
+        "@types/resolve": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
+          "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        }
       }
     },
     "es-module-lexer": {
@@ -2751,6 +2804,15 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*"
+      }
+    },
     "is-regex": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
@@ -3102,6 +3164,15 @@
       "dev": true,
       "requires": {
         "yallist": "^3.0.2"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "map-stream": {
@@ -3575,17 +3646,32 @@
         "fsevents": "~2.1.2"
       }
     },
-    "rollup-plugin-node-resolve": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz",
-      "integrity": "sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==",
+    "rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
       "dev": true,
       "requires": {
-        "@types/resolve": "0.0.8",
-        "builtin-modules": "^3.1.0",
-        "is-module": "^1.0.0",
-        "resolve": "^1.11.1",
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
         "rollup-pluginutils": "^2.8.1"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+          "dev": true
+        }
+      }
+    },
+    "rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "requires": {
+        "rollup-plugin-inject": "^3.0.0"
       }
     },
     "rollup-pluginutils": {
@@ -3667,6 +3753,12 @@
           "dev": true
         }
       }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "split": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "module": "lib/code-sample-editor.js",
   "main": "lib/code-sample-editor.js",
   "scripts": {
-    "build": "npm run build:lib && npm run build:worker",
+    "build": "npm run build:lib && npm run bundle",
     "build:lib": "tsc --build",
-    "build:worker": "rollup -c rollup.config.js",
-    "watch": "tsc-watch --build --onSuccess \"rollup -c rollup.config.js\"",
+    "bundle": "rollup -c rollup.config.js",
+    "watch": "tsc --build --watch & rollup -c rollup.config.js -w",
     "serve": "es-dev-server --node-resolve --event-stream=false",
     "dev": "npm run watch & npm run serve",
     "format": "prettier src/**/*.ts --write",
@@ -18,10 +18,12 @@
   "author": "The Polymer Authors",
   "license": "BSD-3-Clause",
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^14.0.0",
+    "@rollup/plugin-node-resolve": "^8.4.0",
     "es-dev-server": "^1.57.4",
     "prettier": "^2.0.5",
     "rollup": "^2.21.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
+    "rollup-plugin-node-polyfills": "^0.2.1",
     "tsc-watch": "^4.2.3",
     "typescript": "^3.9.7"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
 
 export default [
   {
@@ -9,5 +10,18 @@ export default [
       exports: 'none',
     },
     plugins: [resolve()],
+  }, {
+    input: 'typescript-worker/typescript-worker.js',
+    output: {
+      file: 'typescript-worker.js',
+      format: 'iife',
+      exports: 'none',
+    },
+    plugins: [
+      commonjs({
+        ignore: (id) => true,
+      }),
+      resolve(),
+    ],
   }
 ]

--- a/src/lib/codemirror-editor.ts
+++ b/src/lib/codemirror-editor.ts
@@ -82,7 +82,7 @@ export class CodeMirrorEditorElement extends LitElement {
    * extension.
    */
   @property()
-  type: 'js' | 'html' | 'css' | undefined;
+  type: 'js' | 'ts' | 'html' | 'css' | undefined;
 
   render() {
     return html`${this._editorView?.dom}`;

--- a/src/typescript-worker/tsconfig.json
+++ b/src/typescript-worker/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "../../typescript-worker",
+    "rootDir": ".",
+    "lib": [
+      "ES2017",
+      "WebWorker"
+    ],
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+  },
+  "include": [
+    "*.ts",
+  ],
+  "exclude": [],
+  "references": [
+    {
+      "path": "../shared"
+    }
+  ]
+}

--- a/src/typescript-worker/typescript-worker.ts
+++ b/src/typescript-worker/typescript-worker.ts
@@ -1,0 +1,352 @@
+/**
+ * @license
+ * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {TypeScriptWorkerAPI, SampleFile} from '../shared/worker-api.js';
+import {expose} from 'comlink';
+import * as ts from 'typescript';
+
+const compilerOptions = {
+  target: ts.ScriptTarget.ES2017,
+  module: ts.ModuleKind.ESNext,
+  experimentalDecorators: true,
+  skipDefaultLibCheck: true,
+  skipLibCheck: true,
+  moduleResolution: ts.ModuleResolutionKind.NodeJs,
+};
+
+/**
+ * Rewrites bare module specifiers to unpkg.com URLs. For now, uses unpkg.com
+ * module resolution from there on. We might want to change this and do all
+ * rewrites ourselves to ensure less module duplication.
+ */
+const makeBareSpecifierTransformVisitor = (
+  context: ts.TransformationContext
+): ts.Visitor => {
+  const visitor: ts.Visitor = (node) => {
+    if (ts.isImportDeclaration(node)) {
+      const specifier = (node.moduleSpecifier as ts.StringLiteral).text;
+      const {type, url} = resolveSpecifier(specifier, self.origin);
+      if (type === 'bare') {
+        const newNode = ts.getMutableClone(node);
+        newNode.moduleSpecifier = ts.createStringLiteral(url + '?module');
+        return newNode;
+      }
+    }
+    return ts.visitEachChild(node, visitor, context);
+  };
+  return visitor;
+};
+
+const transformers: ts.CustomTransformers = {
+  after: [
+    (context: ts.TransformationContext) => <T extends ts.Node>(node: T) => {
+      return ts.visitNode(node, makeBareSpecifierTransformVisitor(context));
+    },
+  ],
+};
+
+const workerAPI: TypeScriptWorkerAPI = {
+  /**
+   * Compiles a project, returning a Map of compiled file contents. The map
+   * only contains context for files that are compiled. Other files are skipped.
+   *
+   * TODO (justinfagnani): This does a new compilation for each call, we should
+   * keep the Program in memory and accept updates to the files to do
+   * incremental compilation. We could also share a DocumentRegistry across
+   * multiple code-sample-editor instances to save memory and type analysis of
+   * common lib files like lit-element, lib.d.ts and dom.d.ts.
+   */
+  async compileProject(files: Array<SampleFile>) {
+    const loadedFiles = await loadFiles(files);
+    const languageServiceHost = new WorkerLanguageServiceHost(
+      loadedFiles,
+      self.origin,
+      compilerOptions
+    );
+    const languageService = ts.createLanguageService(
+      languageServiceHost,
+      ts.createDocumentRegistry()
+    );
+    const program = languageService.getProgram();
+    const emittedFiles = new Map<string, string>();
+    for (const file of files) {
+      // Request an emit for ach TypeScritp file
+      if (file.name.endsWith('.ts')) {
+        const url = new URL(file.name, self.origin).href;
+        const sourceFile = program!.getSourceFile(url);
+        program!.emit(
+          sourceFile,
+          (fileName: string, data: string) => {
+            emittedFiles.set(fileName, data);
+          },
+          undefined,
+          undefined,
+          transformers
+        );
+      }
+    }
+    return emittedFiles;
+  },
+};
+expose(workerAPI);
+
+type ResolvedFileRecord = {
+  status: 'resolved';
+  originalUrl?: string;
+  content: string;
+  // contentType: string;
+};
+type RedirectedFileRecord = {
+  status: 'redirected';
+  redirectedUrl: string;
+};
+type PendingFileRecord = {
+  status: 'pending';
+};
+type FileRecord = PendingFileRecord | ResolvedFileRecord | RedirectedFileRecord;
+
+/**
+ * Loads source files and their imports. Returns a Map of FileRecords, with
+ * entries for the given source files and other source files in the module graph.
+ *
+ * Also includes entries for the expected output of compilation, ie a .ts source
+ * file will have entries for the .ts source and a redirect entry for the .js
+ * file so that imports of the .js file are mapped back to the .ts file like in
+ * tsc.
+ *
+ * Note that this loader is not recursive yet - it only loads the direct
+ * dependencies of the source files, and relies on unpkg.com for transitive
+ * dependencies to load in the preview iframe. In order to enable propert type
+ * checking we will load the entire module graph here.
+ */
+const loadFiles = (
+  files: Array<SampleFile>
+): Promise<Map<string, FileRecord>> => {
+  return new Promise(async (resolve, _reject) => {
+    const fileRecords = new Map<string, FileRecord>();
+    let pendingFileCount = 0;
+
+    // Prime the file map with the sample files so they're marked as already
+    // loaded.
+    for (const file of files) {
+      // TODO: include session/scope id?
+      const url = new URL(file.name, self.origin).href;
+
+      // .ts files are imported with .js extensions. Since we aim to redirect
+      // .js imports to either .ts or .d.ts files when available, we add a
+      // redirect for the .js extension.
+      // TODO (justinfagnani): handle .d.ts files
+      if (url.endsWith('.ts')) {
+        const redirectedUrl = changeExtension(url, 'js');
+
+        // Redirect .js -> .ts
+        fileRecords.set(redirectedUrl, {
+          status: 'redirected',
+          redirectedUrl: url,
+        });
+
+        // .ts has the content
+        fileRecords.set(url, {
+          status: 'resolved',
+          originalUrl: redirectedUrl,
+          content: file.content,
+        });
+      } else {
+        fileRecords.set(url, {
+          status: 'resolved',
+          content: file.content,
+        });
+      }
+    }
+
+    // For each file, fetch its imports
+    for (const file of files) {
+      if (file.name.endsWith('.ts')) {
+        const referrerUrl = new URL(file.name, self.origin);
+        const preProcessedFile = ts.preProcessFile(
+          file.content,
+          undefined,
+          true
+        );
+
+        for (const importedFile of preProcessedFile.importedFiles) {
+          const specifier = importedFile.fileName;
+          const {type, url} = resolveSpecifier(specifier, referrerUrl);
+
+          if (!fileRecords.has(url)) {
+            pendingFileCount++;
+
+            // Synchronously set the file to pending so subsequent imports don't
+            // trigger another loading task.
+            fileRecords.set(url, {
+              status: 'pending',
+            });
+
+            // Async task to load the imported file
+            (async () => {
+              const response = await fetch(url);
+
+              if (type === 'bare') {
+                // Fetch any types. Doesn't yet look in package.json
+                const resolvedUrl = new URL(response.url);
+                if (resolvedUrl.pathname.endsWith('.js')) {
+                  const typesUrl = new URL(resolvedUrl.href);
+                  typesUrl.pathname = changeExtension(
+                    resolvedUrl.pathname,
+                    'd.ts'
+                  );
+                  const typesResponse = await fetch(resolvedUrl.href);
+                  if (typesResponse.ok) {
+                    // TODO: store both .js and .d.ts content?
+                    // TODO: store original file and types in same file record?
+                    // Redirects .js -> .d.ts
+                    fileRecords.set(url, {
+                      status: 'redirected',
+                      redirectedUrl: typesUrl.href,
+                    });
+                    fileRecords.set(typesUrl.href, {
+                      status: 'resolved',
+                      content: await typesResponse.text(),
+                    });
+                  } else {
+                    fileRecords.set(url, {
+                      status: 'resolved',
+                      content: await response.text(),
+                    });
+                  }
+                } else {
+                  // Dunno what type of file this would be? A CSS import?
+                  fileRecords.set(url, {
+                    status: 'resolved',
+                    content: await response.text(),
+                  });
+                }
+              } else {
+                // Presumably this isn't an import of a sample file, because
+                // it would have been pre-loaded in the file map
+                fileRecords.set(url, {
+                  status: 'resolved',
+                  content: await response.text(),
+                });
+              }
+
+              pendingFileCount--;
+              if (pendingFileCount === 0) {
+                resolve(fileRecords);
+              }
+            })();
+          }
+        }
+      }
+    }
+    if (pendingFileCount === 0) {
+      resolve(fileRecords);
+    }
+  });
+};
+
+const changeExtension = (path: string, ext: string) => {
+  const lastDotIndex = path.lastIndexOf('.');
+  return path.slice(0, lastDotIndex + 1) + ext;
+};
+
+const isRelativeOrAbsolutePath = (s: string) =>
+  s.match(/^(\.){0,2}\//) !== null;
+
+type ResolvedSpecifier = {
+  type: 'url' | 'relative' | 'bare';
+  url: string;
+};
+
+/**
+ * Resolve an import specifier. Uses HTML-spec semantics for URLs and relative
+ * paths, and returns an unpkg.com URL for bare-specifiers.
+ */
+const resolveSpecifier = (
+  specifier: string,
+  referrer: string | URL
+): ResolvedSpecifier => {
+  try {
+    return {
+      type: 'url' as const,
+      url: new URL(specifier).href,
+    };
+  } catch (e) {
+    if (isRelativeOrAbsolutePath(specifier)) {
+      return {
+        type: 'relative' as const,
+        url: new URL(specifier, referrer).href,
+      };
+    }
+    return {
+      type: 'bare' as const,
+      url: `https://unpkg.com/${specifier}`,
+    };
+  }
+};
+
+class WorkerLanguageServiceHost implements ts.LanguageServiceHost {
+  compilerOptions: ts.CompilerOptions;
+  packageRoot: string;
+  files: Map<string, FileRecord>;
+
+  constructor(
+    files: Map<string, FileRecord>,
+    packageRoot: string,
+    compilerOptions: ts.CompilerOptions
+  ) {
+    this.packageRoot = packageRoot;
+    this.compilerOptions = compilerOptions;
+    this.files = files;
+  }
+
+  getCompilationSettings(): ts.CompilerOptions {
+    return this.compilerOptions;
+  }
+
+  getScriptFileNames(): string[] {
+    return Array.from(this.files.keys());
+  }
+
+  getScriptVersion(_fileName: string) {
+    return '-1';
+  }
+
+  fileExists(fileName: string): boolean {
+    return this.files.has(fileName);
+  }
+
+  readFile(fileName: string): string | undefined {
+    const file = this.files.get(fileName);
+    if (file !== undefined && file.status === 'resolved') {
+      return file.content;
+    }
+    return undefined;
+  }
+
+  getScriptSnapshot(fileName: string): ts.IScriptSnapshot | undefined {
+    if (!this.fileExists(fileName)) {
+      return undefined;
+    }
+    return ts.ScriptSnapshot.fromString(this.readFile(fileName)!);
+  }
+
+  getCurrentDirectory(): string {
+    return this.packageRoot;
+  }
+
+  getDefaultLibFileName(_options: ts.CompilerOptions): string {
+    return '__lib.d.ts';
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,9 @@
     },
     {
       "path": "src/shared"
+    },
+    {
+      "path": "src/typescript-worker"
     }
   ]
 }


### PR DESCRIPTION
Adds a TypeScript worker to compile sample source files. There is one worker per instance of code-sample-editor.

The loading and compiler setup is pretty basic still, but enough to run TypeScript samples. More work will have to be done to get full type-checking: recursively loading _all_ files, loading the correct lib files, and doing a better job of loading .d.ts files for .js dependencies.