### PR TITLE
Allow injected CodeMirror styles to survive lit rendering

### DIFF
--- a/src/lib/codemirror-editor.ts
+++ b/src/lib/codemirror-editor.ts
@@ -67,7 +67,7 @@ export class CodeMirrorEditorElement extends LitElement {
   // that we can set this value internally without triggering an update.
   private _value?: string;
 
-  private _capturedCodeMirrorStyles: HTMLStyleElement[] = [];
+  private _capturedCodeMirrorStyles?: NodeListOf<HTMLStyleElement>;
 
   get value() {
     return this._value;
@@ -87,10 +87,7 @@ export class CodeMirrorEditorElement extends LitElement {
   type: 'js' | 'ts' | 'html' | 'css' | undefined;
 
   render() {
-    return html`
-      ${this._capturedCodeMirrorStyles}
-      ${this._editorView?.dom}
-    `;
+    return html` ${this._editorView?.dom} ${this._capturedCodeMirrorStyles} `;
   }
 
   update(changedProperties: PropertyValues) {
@@ -133,11 +130,12 @@ export class CodeMirrorEditorElement extends LitElement {
       root: this.shadowRoot!,
     });
     // EditorView writes a <style> directly into the given root on construction
-    // (unless adopted stylesheets are available in which case it uses that).
+    // (unless adopted stylesheets are available, in which case it uses that).
     // But then lit renders and blows it away. So, we'll just snatch any new
-    // styles beefore this can happen, and then have lit put them back again.
-    this._capturedCodeMirrorStyles = Array.from(
-      this.shadowRoot!.querySelectorAll('style'));
+    // styles before this can happen, and then have lit put them back again.
+    // Note that EditorView re-uses the same <style> element across instances,
+    // so our list of styles does not grow every time we reset the view.
+    this._capturedCodeMirrorStyles = this.shadowRoot!.querySelectorAll('style');
     this._editorView = view;
     this.requestUpdate();
   }

--- a/src/lib/codemirror-editor.ts
+++ b/src/lib/codemirror-editor.ts
@@ -67,6 +67,8 @@ export class CodeMirrorEditorElement extends LitElement {
   // that we can set this value internally without triggering an update.
   private _value?: string;
 
+  private _capturedCodeMirrorStyles: HTMLStyleElement[] = [];
+
   get value() {
     return this._value;
   }
@@ -85,7 +87,10 @@ export class CodeMirrorEditorElement extends LitElement {
   type: 'js' | 'ts' | 'html' | 'css' | undefined;
 
   render() {
-    return html`${this._editorView?.dom}`;
+    return html`
+      ${this._capturedCodeMirrorStyles}
+      ${this._editorView?.dom}
+    `;
   }
 
   update(changedProperties: PropertyValues) {
@@ -127,6 +132,12 @@ export class CodeMirrorEditorElement extends LitElement {
       }),
       root: this.shadowRoot!,
     });
+    // EditorView writes a <style> directly into the given root on construction
+    // (unless adopted stylesheets are available in which case it uses that).
+    // But then lit renders and blows it away. So, we'll just snatch any new
+    // styles beefore this can happen, and then have lit put them back again.
+    this._capturedCodeMirrorStyles = Array.from(
+      this.shadowRoot!.querySelectorAll('style'));
     this._editorView = view;
     this.requestUpdate();
   }


### PR DESCRIPTION
Styles were wonky in Firefox and Safari because `EditorView` writes a `<style>` directly into the given root on construction (unless adopted stylesheets are available in which case it uses that, which is why Chrome was not affected). But then lit was rendering and blowing it away.

So my really hacky solution is to snatch the styles `EditorView` injects before the lit render clobber happens, and then tell lit to render them back again itself.

cc @e111077 