### PR TITLE
Workaround Safari crash, use MWC canary, build SW, use abs paths in demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -73,20 +73,20 @@ export class MySecondElement extends LitElement {
     Note that imports to other TypeScript files use the .js extension like
     you would with tsc.
   </p>
-  <code-sample-editor project-src="./typescript/project.json"></code-sample-editor>
+  <code-sample-editor project-src="/demo/typescript/project.json"></code-sample-editor>
 
   <h2>Basic Project</h2>
   <p>
     An index.html and two local .js file, importing an npm package with bare
     module specifiers.
   </p>
-  <code-sample-editor project-src="./project-1/project.json"></code-sample-editor>
+  <code-sample-editor project-src="/demo/project-1/project.json"></code-sample-editor>
 
   <h2>MWC Demo</h2>
   <p>
     A demo for <code>&lt;mwc-button></code>.
   </p>
-  <code-sample-editor project-src="./mwc-button/project.json"></code-sample-editor>
+  <code-sample-editor project-src="/demo/mwc-button/project.json"></code-sample-editor>
 </body>
 
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1049,364 +1049,364 @@
       }
     },
     "@material/animation": {
-      "version": "8.0.0-canary.096a7a066.0",
-      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-8.0.0-canary.096a7a066.0.tgz",
-      "integrity": "sha512-hGL6sMGcyd9JoxcyhRkAhD6KKQwZVRkhaFcra9YMBYHUbWRxfUbfDTjUZ3ZxmLDDcsjL4Hqjblet6Xmtq3Br5g==",
+      "version": "8.0.0-canary.38ef4501f.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-8.0.0-canary.38ef4501f.0.tgz",
+      "integrity": "sha512-vd81iIYRzTHxkhOUIO+xb3jtaLLZvK9EMdOvRKL0LHFMvY3+RcopYGoys//mhFAMNifn7Hpdtnav94xMzDJLEA==",
       "requires": {
         "tslib": "^1.9.3"
       }
     },
     "@material/base": {
-      "version": "8.0.0-canary.096a7a066.0",
-      "resolved": "https://registry.npmjs.org/@material/base/-/base-8.0.0-canary.096a7a066.0.tgz",
-      "integrity": "sha512-y+69zqBP2dt86evkMnFbQPCGYp5su6JBzNyWEa3qtmH0J7pUf+H1879EZabsaFM1Q6ko6IWewlnBx5g8xfoFvg==",
+      "version": "8.0.0-canary.38ef4501f.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-8.0.0-canary.38ef4501f.0.tgz",
+      "integrity": "sha512-9yWf9Etb7mzizt4qav7tbd5ayMuD1j/LrTPyZI7Jtnzh8rq7SvnOUC5iKqxMDq5rTFbiGOtCQZlhq3EG///hbw==",
       "requires": {
         "tslib": "^1.9.3"
       }
     },
     "@material/density": {
-      "version": "8.0.0-canary.096a7a066.0",
-      "resolved": "https://registry.npmjs.org/@material/density/-/density-8.0.0-canary.096a7a066.0.tgz",
-      "integrity": "sha512-sGRHzwnQk67oOpioW5NpJJbAPVPZCRZb8RE1pnwn+/6JjtFtnkSMlAGfl8NMQR+VuXkoLXORA5wOjDf0vOZJ4Q=="
+      "version": "8.0.0-canary.38ef4501f.0",
+      "resolved": "https://registry.npmjs.org/@material/density/-/density-8.0.0-canary.38ef4501f.0.tgz",
+      "integrity": "sha512-Zg/RqOo08CTG7ncxllTjntzfp+6eLRC+IQ8brJBJVKDGuS1dijc3vzUc46Xu0Cve8o+15SRRrNxMElpL1xjr4A=="
     },
     "@material/dom": {
-      "version": "8.0.0-canary.096a7a066.0",
-      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-8.0.0-canary.096a7a066.0.tgz",
-      "integrity": "sha512-JfMeg+lORzHouIWBaL8HbfNutH6mAMUHv649TJEZSMIp7lkrBUXnXdJNP1CybqHKqVbNlMAIb41PBJm93tpxUw==",
+      "version": "8.0.0-canary.38ef4501f.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-8.0.0-canary.38ef4501f.0.tgz",
+      "integrity": "sha512-eCyTFQMHgZ7bfCIRAdxYWuYbGjnPbgckC7Jxd4YiKYANGLxA2jLoqi/yXt5LcmsDCcKmU6aeYZsIxGGId/21yg==",
       "requires": {
-        "@material/feature-targeting": "8.0.0-canary.096a7a066.0",
+        "@material/feature-targeting": "8.0.0-canary.38ef4501f.0",
         "tslib": "^1.9.3"
       }
     },
     "@material/feature-targeting": {
-      "version": "8.0.0-canary.096a7a066.0",
-      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-8.0.0-canary.096a7a066.0.tgz",
-      "integrity": "sha512-5nxnG08PjdwhrLMNxfeCOImbdEtP/bVveOVr72hdqldHuwfnzNjp0lwWAAh/QZrpJNl4Ve2Cnp/LkRnlOELIkw=="
+      "version": "8.0.0-canary.38ef4501f.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-8.0.0-canary.38ef4501f.0.tgz",
+      "integrity": "sha512-j3UoMM3YXWFIf+EBGncbbGQ4AV9ZC4FP9JhJCbqvJTrJAeBAcPNCv7gPhmQCPm8PwDJOd6ZTfvwFhMCD2o6+nQ=="
     },
     "@material/floating-label": {
-      "version": "8.0.0-canary.096a7a066.0",
-      "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-8.0.0-canary.096a7a066.0.tgz",
-      "integrity": "sha512-ec+r6cZXQP2K/W4cbXkMdXPQvfmwddZreGktKpbsUtiFGZEjj5Y/yAPmXFSTUXIEpPpJDoF5GBOlADW0N2KLrQ==",
+      "version": "8.0.0-canary.38ef4501f.0",
+      "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-8.0.0-canary.38ef4501f.0.tgz",
+      "integrity": "sha512-yUmSu7vISF3yaP9BwH63LDy23kqc8Bo2Cclw1syWM/j55aY3XPVaNk+n3V2AjsgxHpIhPphdPc7j0ibUExDiow==",
       "requires": {
-        "@material/animation": "8.0.0-canary.096a7a066.0",
-        "@material/base": "8.0.0-canary.096a7a066.0",
-        "@material/dom": "8.0.0-canary.096a7a066.0",
-        "@material/feature-targeting": "8.0.0-canary.096a7a066.0",
-        "@material/rtl": "8.0.0-canary.096a7a066.0",
-        "@material/theme": "8.0.0-canary.096a7a066.0",
-        "@material/typography": "8.0.0-canary.096a7a066.0",
+        "@material/animation": "8.0.0-canary.38ef4501f.0",
+        "@material/base": "8.0.0-canary.38ef4501f.0",
+        "@material/dom": "8.0.0-canary.38ef4501f.0",
+        "@material/feature-targeting": "8.0.0-canary.38ef4501f.0",
+        "@material/rtl": "8.0.0-canary.38ef4501f.0",
+        "@material/theme": "8.0.0-canary.38ef4501f.0",
+        "@material/typography": "8.0.0-canary.38ef4501f.0",
         "tslib": "^1.9.3"
       }
     },
     "@material/line-ripple": {
-      "version": "8.0.0-canary.096a7a066.0",
-      "resolved": "https://registry.npmjs.org/@material/line-ripple/-/line-ripple-8.0.0-canary.096a7a066.0.tgz",
-      "integrity": "sha512-7Sefq4e5wAZbK75tZ3NaMVtvtAPO34NwZIOeTSf9NAdqRanoYDUae2rLBo4i72jOTtGat8qegbIJDoNxRF8+BA==",
+      "version": "8.0.0-canary.38ef4501f.0",
+      "resolved": "https://registry.npmjs.org/@material/line-ripple/-/line-ripple-8.0.0-canary.38ef4501f.0.tgz",
+      "integrity": "sha512-z1lXbkOHzUQZSJkxeJciB7CGUMLBYXHWVZWs5vl8Aktx91JqaaNEQfcqWOSWr/jU9KQiZESCJMo3vkyFSum55Q==",
       "requires": {
-        "@material/animation": "8.0.0-canary.096a7a066.0",
-        "@material/base": "8.0.0-canary.096a7a066.0",
-        "@material/feature-targeting": "8.0.0-canary.096a7a066.0",
-        "@material/theme": "8.0.0-canary.096a7a066.0",
+        "@material/animation": "8.0.0-canary.38ef4501f.0",
+        "@material/base": "8.0.0-canary.38ef4501f.0",
+        "@material/feature-targeting": "8.0.0-canary.38ef4501f.0",
+        "@material/theme": "8.0.0-canary.38ef4501f.0",
         "tslib": "^1.9.3"
       }
     },
     "@material/mwc-base": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@material/mwc-base/-/mwc-base-0.18.0.tgz",
-      "integrity": "sha512-75CuivLaw7lSaIrkPvBaYyD6AwbYEu0M7sgnNAvHK/W5nrK1GViLJIKG87edCHhSRshZVjnDpyDIBJMR7yj03g==",
+      "version": "0.19.0-canary.615d861d.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-base/-/mwc-base-0.19.0-canary.615d861d.0.tgz",
+      "integrity": "sha512-3bi8AE1YMfQucJa+TwQwu33rZ3c5bQB0chipm36HRX7xXgBjbdjbYF75u2chdTg0tRuH+KeW4VDFmw/rPhG7nw==",
       "requires": {
-        "@material/base": "=8.0.0-canary.096a7a066.0",
-        "@material/dom": "=8.0.0-canary.096a7a066.0",
+        "@material/base": "=8.0.0-canary.38ef4501f.0",
+        "@material/dom": "=8.0.0-canary.38ef4501f.0",
         "lit-element": "^2.3.0",
         "tslib": "^1.10.0"
       }
     },
     "@material/mwc-button": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@material/mwc-button/-/mwc-button-0.18.0.tgz",
-      "integrity": "sha512-TeUcsnTIiAkG8B3Pz4QNgiudbUBY66Yf9tZVHLGEPeKZENtwTbg/C6fMDdxsvEl/nlCrBTcTFaUNeawMIqhTDw==",
+      "version": "0.19.0-canary.615d861d.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-button/-/mwc-button-0.19.0-canary.615d861d.0.tgz",
+      "integrity": "sha512-EHJeWptjxlM8jvgQMMAXZrlkdVWpqc4c1SQV2V2sa1Ck48lmHc873C1ZkM8+MEcIkPUesYKHdSB8aK+EaUkMvQ==",
       "requires": {
-        "@material/mwc-icon": "^0.18.0",
-        "@material/mwc-ripple": "^0.18.0",
+        "@material/mwc-icon": "0.19.0-canary.615d861d.0",
+        "@material/mwc-ripple": "0.19.0-canary.615d861d.0",
         "lit-element": "^2.3.0",
         "lit-html": "^1.1.2",
         "tslib": "^1.10.0"
       }
     },
     "@material/mwc-floating-label": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@material/mwc-floating-label/-/mwc-floating-label-0.18.0.tgz",
-      "integrity": "sha512-0HLMrd8/hsvUprXjsebc/OVOoGe1A8BK/U2y+PJj57DpWyNsmLCWFDsR9BCiCmt3LTYWq+mez6kB64qgY2wgIA==",
+      "version": "0.19.0-canary.615d861d.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-floating-label/-/mwc-floating-label-0.19.0-canary.615d861d.0.tgz",
+      "integrity": "sha512-Ft/X39S/Lqyh5fMzWU2yaJ3lz+03QRSvROScKC4cByt4/fWbCy9ILJoYcvSR4BSgyTIP1qkuu8CEtmKueiPXUg==",
       "requires": {
-        "@material/floating-label": "=8.0.0-canary.096a7a066.0",
+        "@material/floating-label": "=8.0.0-canary.38ef4501f.0",
         "lit-html": "^1.1.2",
         "tslib": "^1.10.0"
       }
     },
     "@material/mwc-icon": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@material/mwc-icon/-/mwc-icon-0.18.0.tgz",
-      "integrity": "sha512-3tYVi7DqGuL3Rk+iy+O6Mf/yB3Gc70Pf9RKMEXlEbTCilLqKTEDf4qp9RuUMN8QvWBsIH9dBWRvbApItYYgJfA==",
+      "version": "0.19.0-canary.615d861d.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-icon/-/mwc-icon-0.19.0-canary.615d861d.0.tgz",
+      "integrity": "sha512-rcnNcHsEFJ07u/dYydEhXrtjwfI0PXdwpXQzfqP/8/9NOhAfolPws/RrcsTfYRew1m1SzRZoL9a2phgVJCkwFA==",
       "requires": {
         "lit-element": "^2.3.0",
         "tslib": "^1.10.0"
       }
     },
     "@material/mwc-icon-button": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@material/mwc-icon-button/-/mwc-icon-button-0.18.0.tgz",
-      "integrity": "sha512-SNHkdT5vZTt1NjN4eUzZcCd5wdhOIqk1gbe13VJYiEhIiLD8xT1NobaHAPKozEqZaBOvQTDQX7qdA/VOEmbjCw==",
+      "version": "0.19.0-canary.615d861d.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-icon-button/-/mwc-icon-button-0.19.0-canary.615d861d.0.tgz",
+      "integrity": "sha512-tQyfV0eCEYl13Fc8s6BjGA1GY3TDLcCiYzEzw02F3s5YXfiOp5gi+vs2EiEpfUW3cn6+wATT+I/A+7RN3tK6LA==",
       "requires": {
-        "@material/mwc-ripple": "^0.18.0",
+        "@material/mwc-ripple": "0.19.0-canary.615d861d.0",
         "lit-element": "^2.3.0",
         "tslib": "^1.10.0"
       }
     },
     "@material/mwc-line-ripple": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@material/mwc-line-ripple/-/mwc-line-ripple-0.18.0.tgz",
-      "integrity": "sha512-VUP+QgLfwUwRLgFpcZYh/nplFqvLiUMLRMMYAIeidlIqaNpV0YqtcBeOrd8y4IfSNCYBfZeDZs08Kj4afCrKfg==",
+      "version": "0.19.0-canary.615d861d.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-line-ripple/-/mwc-line-ripple-0.19.0-canary.615d861d.0.tgz",
+      "integrity": "sha512-LV/rkQwhTLuPSQxCppHv4gAQl8Kv5LpI4bWPB63BV1G4zQNyfpLyOpaCEG55+gow7MJokTj68Ij4T2SE39I8bw==",
       "requires": {
-        "@material/line-ripple": "=8.0.0-canary.096a7a066.0",
+        "@material/line-ripple": "=8.0.0-canary.38ef4501f.0",
         "lit-html": "^1.1.2",
         "tslib": "^1.10.0"
       }
     },
     "@material/mwc-notched-outline": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@material/mwc-notched-outline/-/mwc-notched-outline-0.18.0.tgz",
-      "integrity": "sha512-vzZP7qVV1uuLoDAbSS+nz25CJcA0Ir19ouoaZGsnT1m5X7M/Hj0KTraRdtaph1ECcBp/oI9LSQlV7fwEBI8Gxg==",
+      "version": "0.19.0-canary.615d861d.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-notched-outline/-/mwc-notched-outline-0.19.0-canary.615d861d.0.tgz",
+      "integrity": "sha512-6I9AQWEkMvaWsiHNwnuXQlvoQivDva+4Hyts/Q9jJaWr8z9XijAYWl2OspVRPmR3vo3d37NF8YCTNaUNcg4CGA==",
       "requires": {
-        "@material/mwc-base": "^0.18.0",
-        "@material/notched-outline": "=8.0.0-canary.096a7a066.0",
+        "@material/mwc-base": "0.19.0-canary.615d861d.0",
+        "@material/notched-outline": "=8.0.0-canary.38ef4501f.0",
         "lit-element": "^2.3.0",
         "lit-html": "^1.1.2",
         "tslib": "^1.10.0"
       }
     },
     "@material/mwc-ripple": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@material/mwc-ripple/-/mwc-ripple-0.18.0.tgz",
-      "integrity": "sha512-6+7QQmMXmbd42rQOPEmMnY7Sp7EsewI7Ar0N/d6MNrd+4LIcC+G9+mIambZ+r5Gs7i3/HTBdehKl37jCW5Equw==",
+      "version": "0.19.0-canary.615d861d.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-ripple/-/mwc-ripple-0.19.0-canary.615d861d.0.tgz",
+      "integrity": "sha512-K9Ufpuef5YQjpPwp0ZC1LhXtyyQmQUxIVM9s4bfj3x/RA0imhLrZtz/YRYm2o2Y8dyCmJ+XjL+1NaU4CM1J/kQ==",
       "requires": {
-        "@material/dom": "=8.0.0-canary.096a7a066.0",
-        "@material/mwc-base": "^0.18.0",
-        "@material/ripple": "=8.0.0-canary.096a7a066.0",
+        "@material/dom": "=8.0.0-canary.38ef4501f.0",
+        "@material/mwc-base": "0.19.0-canary.615d861d.0",
+        "@material/ripple": "=8.0.0-canary.38ef4501f.0",
         "lit-element": "^2.3.0",
         "lit-html": "^1.1.2",
         "tslib": "^1.10.0"
       }
     },
     "@material/mwc-tab": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@material/mwc-tab/-/mwc-tab-0.18.0.tgz",
-      "integrity": "sha512-m6EvOsVBwF5CxdhMls1RkKcJGhhDO0Kg1eyi4nXxba8PHZx3KbzeMsR+VlYxo/rBrnA1tDzKv9b0H2Dn0KrVIw==",
+      "version": "0.19.0-canary.615d861d.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-tab/-/mwc-tab-0.19.0-canary.615d861d.0.tgz",
+      "integrity": "sha512-vnypXVvFelOvVdndxb8T/yN3KyT57Gy9CyddxvXA2TNTcFU4ZTHP+d/ZADS0O1iPgH7XNiy2Bq/4ksREL7KDnQ==",
       "requires": {
-        "@material/mwc-base": "^0.18.0",
-        "@material/mwc-ripple": "^0.18.0",
-        "@material/mwc-tab-indicator": "^0.18.0",
-        "@material/tab": "=8.0.0-canary.096a7a066.0",
+        "@material/mwc-base": "0.19.0-canary.615d861d.0",
+        "@material/mwc-ripple": "0.19.0-canary.615d861d.0",
+        "@material/mwc-tab-indicator": "0.19.0-canary.615d861d.0",
+        "@material/tab": "=8.0.0-canary.38ef4501f.0",
         "lit-element": "^2.3.0",
         "lit-html": "^1.1.2",
         "tslib": "^1.10.0"
       }
     },
     "@material/mwc-tab-bar": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@material/mwc-tab-bar/-/mwc-tab-bar-0.18.0.tgz",
-      "integrity": "sha512-9cSXBSll6OfMW/Tqm6edkHqKH3/fR50wRXY0EIz8S3jSjuf39O9Wv5fNLY3L9+wNnTc5hWYGHT4jNDkE0TIwvg==",
+      "version": "0.19.0-canary.615d861d.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-tab-bar/-/mwc-tab-bar-0.19.0-canary.615d861d.0.tgz",
+      "integrity": "sha512-11Bu/8A3+fDQQDE6H6U0R+AcS5m8tS1RhrY4su0+DaUc8jZaRc4xJ7LbXWHbauW5miBeEcndb3Kc9+KOh9c3Mw==",
       "requires": {
-        "@material/mwc-base": "^0.18.0",
-        "@material/mwc-tab": "^0.18.0",
-        "@material/mwc-tab-scroller": "^0.18.0",
-        "@material/tab": "=8.0.0-canary.096a7a066.0",
-        "@material/tab-bar": "=8.0.0-canary.096a7a066.0",
+        "@material/mwc-base": "0.19.0-canary.615d861d.0",
+        "@material/mwc-tab": "0.19.0-canary.615d861d.0",
+        "@material/mwc-tab-scroller": "0.19.0-canary.615d861d.0",
+        "@material/tab": "=8.0.0-canary.38ef4501f.0",
+        "@material/tab-bar": "=8.0.0-canary.38ef4501f.0",
         "lit-element": "^2.3.0",
         "tslib": "^1.10.0"
       }
     },
     "@material/mwc-tab-indicator": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@material/mwc-tab-indicator/-/mwc-tab-indicator-0.18.0.tgz",
-      "integrity": "sha512-s4toi+yUVxm2my+rAQBo2iFXGI7IhkCLW7UdmdrSfZHpyqUXj3086BuQkWxM6LnNLOsK61DXoxGva+gUczPleg==",
+      "version": "0.19.0-canary.615d861d.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-tab-indicator/-/mwc-tab-indicator-0.19.0-canary.615d861d.0.tgz",
+      "integrity": "sha512-73/EG86twJsWqZzy8HPvNAA8z7+hymrNFN4UCCCqKx44h6+sg4sQCri4cM5ZIikNFFZjVquk4njOjrMkS9hCRQ==",
       "requires": {
-        "@material/mwc-base": "^0.18.0",
-        "@material/tab-indicator": "=8.0.0-canary.096a7a066.0",
+        "@material/mwc-base": "0.19.0-canary.615d861d.0",
+        "@material/tab-indicator": "=8.0.0-canary.38ef4501f.0",
         "lit-element": "^2.3.0",
         "lit-html": "^1.1.2",
         "tslib": "^1.10.0"
       }
     },
     "@material/mwc-tab-scroller": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@material/mwc-tab-scroller/-/mwc-tab-scroller-0.18.0.tgz",
-      "integrity": "sha512-OhHSlltMSIFO9p2PeBj26zbLJzXwaa1L7BPLBjAsesvF0YhrixacTGOYZKMnoMdvQ0WlppDaxLD4mh0P/DDZbg==",
+      "version": "0.19.0-canary.615d861d.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-tab-scroller/-/mwc-tab-scroller-0.19.0-canary.615d861d.0.tgz",
+      "integrity": "sha512-VzGxIW5A8oYw078vTx9sZcZv+5RiyJI0pQPw6Z7UWImRXH1Gy7FbpGEbj9Ub0xOgMi1cgcJVzZ4rC3tZ0teeDg==",
       "requires": {
-        "@material/dom": "=8.0.0-canary.096a7a066.0",
-        "@material/mwc-base": "^0.18.0",
-        "@material/tab-scroller": "=8.0.0-canary.096a7a066.0",
+        "@material/dom": "=8.0.0-canary.38ef4501f.0",
+        "@material/mwc-base": "0.19.0-canary.615d861d.0",
+        "@material/tab-scroller": "=8.0.0-canary.38ef4501f.0",
         "lit-element": "^2.3.0",
         "tslib": "^1.10.0"
       }
     },
     "@material/mwc-textfield": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@material/mwc-textfield/-/mwc-textfield-0.18.0.tgz",
-      "integrity": "sha512-7aWk4+5ZnusIGUPAhy0PaQKBNdkWnE3Ipz4BLNq9X8VqgnNIcod4FpfHcFyFs8+eWXW1I+xf5TUDcfG9MmoM+Q==",
+      "version": "0.19.0-canary.615d861d.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-textfield/-/mwc-textfield-0.19.0-canary.615d861d.0.tgz",
+      "integrity": "sha512-U09PkkE+Z+sdexD9PK+Yim5jAAPK8Rzslr72bH/T0c0DiwxZK01faKLx/zfRyMbODUYVTv2k8h3IJP4Uq2EWbA==",
       "requires": {
-        "@material/floating-label": "=8.0.0-canary.096a7a066.0",
-        "@material/line-ripple": "=8.0.0-canary.096a7a066.0",
-        "@material/mwc-base": "^0.18.0",
-        "@material/mwc-floating-label": "^0.18.0",
-        "@material/mwc-line-ripple": "^0.18.0",
-        "@material/mwc-notched-outline": "^0.18.0",
-        "@material/textfield": "=8.0.0-canary.096a7a066.0",
+        "@material/floating-label": "=8.0.0-canary.38ef4501f.0",
+        "@material/line-ripple": "=8.0.0-canary.38ef4501f.0",
+        "@material/mwc-base": "0.19.0-canary.615d861d.0",
+        "@material/mwc-floating-label": "0.19.0-canary.615d861d.0",
+        "@material/mwc-line-ripple": "0.19.0-canary.615d861d.0",
+        "@material/mwc-notched-outline": "0.19.0-canary.615d861d.0",
+        "@material/textfield": "=8.0.0-canary.38ef4501f.0",
         "lit-element": "^2.3.0",
         "lit-html": "^1.1.2",
         "tslib": "^1.10.0"
       }
     },
     "@material/notched-outline": {
-      "version": "8.0.0-canary.096a7a066.0",
-      "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-8.0.0-canary.096a7a066.0.tgz",
-      "integrity": "sha512-BKJQiHuWEQNXgrTG8AVg4iPm3PvuZ/5Bs/bvW6cBKGsk1Ki0mK1hl3RWG9BqzQ3BR9NV5AmPog6gfnJfpBaH6Q==",
+      "version": "8.0.0-canary.38ef4501f.0",
+      "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-8.0.0-canary.38ef4501f.0.tgz",
+      "integrity": "sha512-21WKznQ9rX+2843munreTNJg28TwGS7MdTFhEtTd4fhK9XABReWMKpZE0x+inGmNkO/nLw7S435d0LlzQGP09A==",
       "requires": {
-        "@material/base": "8.0.0-canary.096a7a066.0",
-        "@material/feature-targeting": "8.0.0-canary.096a7a066.0",
-        "@material/floating-label": "8.0.0-canary.096a7a066.0",
-        "@material/rtl": "8.0.0-canary.096a7a066.0",
-        "@material/shape": "8.0.0-canary.096a7a066.0",
-        "@material/theme": "8.0.0-canary.096a7a066.0",
+        "@material/base": "8.0.0-canary.38ef4501f.0",
+        "@material/feature-targeting": "8.0.0-canary.38ef4501f.0",
+        "@material/floating-label": "8.0.0-canary.38ef4501f.0",
+        "@material/rtl": "8.0.0-canary.38ef4501f.0",
+        "@material/shape": "8.0.0-canary.38ef4501f.0",
+        "@material/theme": "8.0.0-canary.38ef4501f.0",
         "tslib": "^1.9.3"
       }
     },
     "@material/ripple": {
-      "version": "8.0.0-canary.096a7a066.0",
-      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-8.0.0-canary.096a7a066.0.tgz",
-      "integrity": "sha512-SQGYL/arRC76P5kr23i8gkUY4FmJVZN98f2Ke3CTAG8VrecI0uqnmPRtDTC6A8djEbePlEmqDUxnWP+ZoDr9+g==",
+      "version": "8.0.0-canary.38ef4501f.0",
+      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-8.0.0-canary.38ef4501f.0.tgz",
+      "integrity": "sha512-Zo7B33TEVRfyrb8wAkgtZ9yzidgRk3FQrDnZb3zj9yZv5V0ICc0sLRYhDshxL0Lu/UXwhYOEIThxfjZjJhWd4g==",
       "requires": {
-        "@material/animation": "8.0.0-canary.096a7a066.0",
-        "@material/base": "8.0.0-canary.096a7a066.0",
-        "@material/dom": "8.0.0-canary.096a7a066.0",
-        "@material/feature-targeting": "8.0.0-canary.096a7a066.0",
-        "@material/theme": "8.0.0-canary.096a7a066.0",
+        "@material/animation": "8.0.0-canary.38ef4501f.0",
+        "@material/base": "8.0.0-canary.38ef4501f.0",
+        "@material/dom": "8.0.0-canary.38ef4501f.0",
+        "@material/feature-targeting": "8.0.0-canary.38ef4501f.0",
+        "@material/theme": "8.0.0-canary.38ef4501f.0",
         "tslib": "^1.9.3"
       }
     },
     "@material/rtl": {
-      "version": "8.0.0-canary.096a7a066.0",
-      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-8.0.0-canary.096a7a066.0.tgz",
-      "integrity": "sha512-/JpiBQIcva0DRv4WOek+5dWvGmXR6zaEqYmIRZj4w6bWMvCquGqYHUc/xiJdORk8xIKY9zzxY0bOfF0/EIWyVQ==",
+      "version": "8.0.0-canary.38ef4501f.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-8.0.0-canary.38ef4501f.0.tgz",
+      "integrity": "sha512-pkRG0kAyocDus+D7xFvV1X27O4BOyH8cDSDQwtC2uwpuuuYMzKG9zgej3eFJ9NUBi/ig7dJvv7sb1/n6Bpxj/w==",
       "requires": {
-        "@material/theme": "8.0.0-canary.096a7a066.0"
+        "@material/theme": "8.0.0-canary.38ef4501f.0"
       }
     },
     "@material/shape": {
-      "version": "8.0.0-canary.096a7a066.0",
-      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-8.0.0-canary.096a7a066.0.tgz",
-      "integrity": "sha512-UoagRun+cQF2yieE+ErJJQpNLyn2+PU7FifFF7N381sMBQTcxQZ7bFHNkmj1eqUPUsiWxbJxnjsMjQ2Ez5e/Aw==",
+      "version": "8.0.0-canary.38ef4501f.0",
+      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-8.0.0-canary.38ef4501f.0.tgz",
+      "integrity": "sha512-BdiCvaJMNF6h59wkGOlRbH8OIOyz/zTwp2T8nlypaDJu5Zu5LersaKXoC0F0VkvTy6KU9boT4RZljQmojTQ+bA==",
       "requires": {
-        "@material/feature-targeting": "8.0.0-canary.096a7a066.0",
-        "@material/rtl": "8.0.0-canary.096a7a066.0",
-        "@material/theme": "8.0.0-canary.096a7a066.0"
+        "@material/feature-targeting": "8.0.0-canary.38ef4501f.0",
+        "@material/rtl": "8.0.0-canary.38ef4501f.0",
+        "@material/theme": "8.0.0-canary.38ef4501f.0"
       }
     },
     "@material/tab": {
-      "version": "8.0.0-canary.096a7a066.0",
-      "resolved": "https://registry.npmjs.org/@material/tab/-/tab-8.0.0-canary.096a7a066.0.tgz",
-      "integrity": "sha512-M54wiSa2dPzRIIQqA730pwNsrlzYYcGksfWEzgvsUfs4sIo4w/s3672K5LMfbR2qd9AXR6x1Rv9VNqxoj68NyA==",
+      "version": "8.0.0-canary.38ef4501f.0",
+      "resolved": "https://registry.npmjs.org/@material/tab/-/tab-8.0.0-canary.38ef4501f.0.tgz",
+      "integrity": "sha512-iHJxfxh0WDGAcVS/TLqQ/jXSex6FiNk8s6Zr+BQtM/ZukKjjI/aUSTeigguFDpG0AQWbP9w0JpbbJ4v4XYGhIA==",
       "requires": {
-        "@material/base": "8.0.0-canary.096a7a066.0",
-        "@material/feature-targeting": "8.0.0-canary.096a7a066.0",
-        "@material/ripple": "8.0.0-canary.096a7a066.0",
-        "@material/rtl": "8.0.0-canary.096a7a066.0",
-        "@material/tab-indicator": "8.0.0-canary.096a7a066.0",
-        "@material/theme": "8.0.0-canary.096a7a066.0",
-        "@material/typography": "8.0.0-canary.096a7a066.0",
+        "@material/base": "8.0.0-canary.38ef4501f.0",
+        "@material/feature-targeting": "8.0.0-canary.38ef4501f.0",
+        "@material/ripple": "8.0.0-canary.38ef4501f.0",
+        "@material/rtl": "8.0.0-canary.38ef4501f.0",
+        "@material/tab-indicator": "8.0.0-canary.38ef4501f.0",
+        "@material/theme": "8.0.0-canary.38ef4501f.0",
+        "@material/typography": "8.0.0-canary.38ef4501f.0",
         "tslib": "^1.9.3"
       }
     },
     "@material/tab-bar": {
-      "version": "8.0.0-canary.096a7a066.0",
-      "resolved": "https://registry.npmjs.org/@material/tab-bar/-/tab-bar-8.0.0-canary.096a7a066.0.tgz",
-      "integrity": "sha512-lq9HZECqoOfXqXMhFYCrNImKZN8WHjf+fixKMHTIIm/1mG3rAggRgwkAIqDJj6Ysddn/UTsABwXtiv1SMwrH+A==",
+      "version": "8.0.0-canary.38ef4501f.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-bar/-/tab-bar-8.0.0-canary.38ef4501f.0.tgz",
+      "integrity": "sha512-s+LimS2ogLc1f0DpeqZkLaubDfzGI2fWpWZvmOKbvB51JAH4Aj3oednkdA1A1BcZwpb0KEGAKHpAMvD0z8XdcQ==",
       "requires": {
-        "@material/animation": "8.0.0-canary.096a7a066.0",
-        "@material/base": "8.0.0-canary.096a7a066.0",
-        "@material/density": "8.0.0-canary.096a7a066.0",
-        "@material/feature-targeting": "8.0.0-canary.096a7a066.0",
-        "@material/tab": "8.0.0-canary.096a7a066.0",
-        "@material/tab-scroller": "8.0.0-canary.096a7a066.0",
+        "@material/animation": "8.0.0-canary.38ef4501f.0",
+        "@material/base": "8.0.0-canary.38ef4501f.0",
+        "@material/density": "8.0.0-canary.38ef4501f.0",
+        "@material/feature-targeting": "8.0.0-canary.38ef4501f.0",
+        "@material/tab": "8.0.0-canary.38ef4501f.0",
+        "@material/tab-scroller": "8.0.0-canary.38ef4501f.0",
         "tslib": "^1.9.3"
       }
     },
     "@material/tab-indicator": {
-      "version": "8.0.0-canary.096a7a066.0",
-      "resolved": "https://registry.npmjs.org/@material/tab-indicator/-/tab-indicator-8.0.0-canary.096a7a066.0.tgz",
-      "integrity": "sha512-QgoIMscnLCIZmb2yT4ejGwV4jq2b023kVtZCi07sVVd34k2yE+fT0EB1KIKQLb6Ag3yACP1vvjmfPzHbwC2XlA==",
+      "version": "8.0.0-canary.38ef4501f.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-indicator/-/tab-indicator-8.0.0-canary.38ef4501f.0.tgz",
+      "integrity": "sha512-0NA4EnJ0jtIFEA9+edVqDEBkd4NCo0OLJJHE69RSMNcdDJmJbPyap/UGoHVy6FtAQCSQrRtfXZ1KEYNAqMT8cA==",
       "requires": {
-        "@material/animation": "8.0.0-canary.096a7a066.0",
-        "@material/base": "8.0.0-canary.096a7a066.0",
-        "@material/feature-targeting": "8.0.0-canary.096a7a066.0",
-        "@material/theme": "8.0.0-canary.096a7a066.0",
+        "@material/animation": "8.0.0-canary.38ef4501f.0",
+        "@material/base": "8.0.0-canary.38ef4501f.0",
+        "@material/feature-targeting": "8.0.0-canary.38ef4501f.0",
+        "@material/theme": "8.0.0-canary.38ef4501f.0",
         "tslib": "^1.9.3"
       }
     },
     "@material/tab-scroller": {
-      "version": "8.0.0-canary.096a7a066.0",
-      "resolved": "https://registry.npmjs.org/@material/tab-scroller/-/tab-scroller-8.0.0-canary.096a7a066.0.tgz",
-      "integrity": "sha512-IbAd2Zvvk1jQbXr0CeRJYbl0fHCvvZOtlGOeGtn7FYL7bMKEbKJojtymzuNPNhfaqhDBE3ON5Cnr7g0uYE4OEQ==",
+      "version": "8.0.0-canary.38ef4501f.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-scroller/-/tab-scroller-8.0.0-canary.38ef4501f.0.tgz",
+      "integrity": "sha512-WEP9GfF22U/nfLzzILMKdRoVOHcP3LE1Yaot5fONIKo6+1ZMeMBKmsmS/auMAsE9KK13OBGblut9hjrUorrjYw==",
       "requires": {
-        "@material/animation": "8.0.0-canary.096a7a066.0",
-        "@material/base": "8.0.0-canary.096a7a066.0",
-        "@material/dom": "8.0.0-canary.096a7a066.0",
-        "@material/feature-targeting": "8.0.0-canary.096a7a066.0",
-        "@material/tab": "8.0.0-canary.096a7a066.0",
+        "@material/animation": "8.0.0-canary.38ef4501f.0",
+        "@material/base": "8.0.0-canary.38ef4501f.0",
+        "@material/dom": "8.0.0-canary.38ef4501f.0",
+        "@material/feature-targeting": "8.0.0-canary.38ef4501f.0",
+        "@material/tab": "8.0.0-canary.38ef4501f.0",
         "tslib": "^1.9.3"
       }
     },
     "@material/textfield": {
-      "version": "8.0.0-canary.096a7a066.0",
-      "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-8.0.0-canary.096a7a066.0.tgz",
-      "integrity": "sha512-SCzMz6G/sw5onbOko5oM/VwwYwGD97tFnF/Yss/eZCWEHAUWhYZvrzs2oFdAAQKSRgUTiZ5pifNF9rizdwr+EA==",
+      "version": "8.0.0-canary.38ef4501f.0",
+      "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-8.0.0-canary.38ef4501f.0.tgz",
+      "integrity": "sha512-hvaTWVtnOmZiWcHcBBYv4UMCaRvSNIy7D0Mz1VZzg3ofulELgPJWo05x4J5RTUb5fVIA+5P4V2vq6VGZUDaxDw==",
       "requires": {
-        "@material/animation": "8.0.0-canary.096a7a066.0",
-        "@material/base": "8.0.0-canary.096a7a066.0",
-        "@material/density": "8.0.0-canary.096a7a066.0",
-        "@material/dom": "8.0.0-canary.096a7a066.0",
-        "@material/feature-targeting": "8.0.0-canary.096a7a066.0",
-        "@material/floating-label": "8.0.0-canary.096a7a066.0",
-        "@material/line-ripple": "8.0.0-canary.096a7a066.0",
-        "@material/notched-outline": "8.0.0-canary.096a7a066.0",
-        "@material/ripple": "8.0.0-canary.096a7a066.0",
-        "@material/rtl": "8.0.0-canary.096a7a066.0",
-        "@material/shape": "8.0.0-canary.096a7a066.0",
-        "@material/theme": "8.0.0-canary.096a7a066.0",
-        "@material/typography": "8.0.0-canary.096a7a066.0",
+        "@material/animation": "8.0.0-canary.38ef4501f.0",
+        "@material/base": "8.0.0-canary.38ef4501f.0",
+        "@material/density": "8.0.0-canary.38ef4501f.0",
+        "@material/dom": "8.0.0-canary.38ef4501f.0",
+        "@material/feature-targeting": "8.0.0-canary.38ef4501f.0",
+        "@material/floating-label": "8.0.0-canary.38ef4501f.0",
+        "@material/line-ripple": "8.0.0-canary.38ef4501f.0",
+        "@material/notched-outline": "8.0.0-canary.38ef4501f.0",
+        "@material/ripple": "8.0.0-canary.38ef4501f.0",
+        "@material/rtl": "8.0.0-canary.38ef4501f.0",
+        "@material/shape": "8.0.0-canary.38ef4501f.0",
+        "@material/theme": "8.0.0-canary.38ef4501f.0",
+        "@material/typography": "8.0.0-canary.38ef4501f.0",
         "tslib": "^1.9.3"
       }
     },
     "@material/theme": {
-      "version": "8.0.0-canary.096a7a066.0",
-      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-8.0.0-canary.096a7a066.0.tgz",
-      "integrity": "sha512-FdAUEjq7KJ835sobJQL0w0XWD5PabXl77HmBuy5F3bEYbYterWOutvuHbTkAEN6sTzgHCKhdoMubRxMKidqafA==",
+      "version": "8.0.0-canary.38ef4501f.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-8.0.0-canary.38ef4501f.0.tgz",
+      "integrity": "sha512-CpWRIxlkcI+pbAAjBiKoNwNfzCjucoZNyS8m1uS0yEU96rH/YggNL6k6NCmqYXzt9LZdlWY2LIMMkJAOO6mkGQ==",
       "requires": {
-        "@material/feature-targeting": "8.0.0-canary.096a7a066.0"
+        "@material/feature-targeting": "8.0.0-canary.38ef4501f.0"
       }
     },
     "@material/typography": {
-      "version": "8.0.0-canary.096a7a066.0",
-      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-8.0.0-canary.096a7a066.0.tgz",
-      "integrity": "sha512-q6HKSmEWSU9lM3sy1GjiGRskqXWMnwIWWAzet15+Q928JmYBKlw3TLvgfjeeQiaq/c3pHWcGE7Dctk6oNrsQWQ==",
+      "version": "8.0.0-canary.38ef4501f.0",
+      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-8.0.0-canary.38ef4501f.0.tgz",
+      "integrity": "sha512-xda5GffZgxb3J9+Il+UtYGc8xYQg2MXTpL0utS/KW7CPVZPdI+pNa/ReNeCupIUFndkuJytiha1g/M1jORY6NQ==",
       "requires": {
-        "@material/feature-targeting": "8.0.0-canary.096a7a066.0",
-        "@material/theme": "8.0.0-canary.096a7a066.0"
+        "@material/feature-targeting": "8.0.0-canary.38ef4501f.0",
+        "@material/theme": "8.0.0-canary.38ef4501f.0"
       }
     },
     "@open-wc/building-utils": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/@open-wc/building-utils/-/building-utils-2.18.1.tgz",
-      "integrity": "sha512-FBSlR94BwrVlHcaWSESzlYOVLqrUKnC8L88yHajCm/cONaEWYhP/O7SXVHgLnXkjYbCgCGMKbq6fuSnwf5jElQ==",
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/@open-wc/building-utils/-/building-utils-2.18.2.tgz",
+      "integrity": "sha512-oE9cG9X4zpqm9OnQ2s+aaK7pAa8v3wt0YJBhZT3RisoKp/Va4kmsNBTjW2LPkHVK5N0VvPYukS3ey8S53e9ssQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.1",
@@ -1421,7 +1421,7 @@
         "core-js-bundle": "^3.6.0",
         "deepmerge": "^4.2.2",
         "es-module-shims": "^0.4.6",
-        "html-minifier": "^4.0.0",
+        "html-minifier-terser": "^5.1.1",
         "lru-cache": "^5.1.1",
         "minimatch": "^3.0.4",
         "parse5": "^5.1.1",
@@ -1488,9 +1488,9 @@
       }
     },
     "@types/babel__core": {
-      "version": "7.1.9",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
-      "integrity": "sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==",
+      "version": "7.1.10",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.10.tgz",
+      "integrity": "sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -1501,18 +1501,18 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
-      "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+      "integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
     },
     "@types/babel__template": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
-      "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.3.tgz",
+      "integrity": "sha512-uCoznIPDmnickEi6D0v11SBpW0OuVqHJCa7syXqQHy5uktSCreIlt0iglsCnmvz8yCb38hGcWeseA8cWJSwv5Q==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -1520,9 +1520,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.14.tgz",
-      "integrity": "sha512-8w9szzKs14ZtBVuP6Wn7nMLRJ0D6dfB0VEBEyRgxrZ/Ln49aNMykrghM2FaNn4FJRzNppCSa0Rv9pBRM5Xc3wg==",
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.15.tgz",
+      "integrity": "sha512-Pzh9O3sTK8V6I1olsXpCfj2k/ygO2q1X0vhhnDrEQyYLHZesWz+zMZMVcwXLCYf0U36EtmyYaFGPfXlTtDHe3A==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -1629,9 +1629,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.12.tgz",
-      "integrity": "sha512-EaEdY+Dty1jEU7U6J4CUWwxL+hyEGMkO5jan5gplfegUgCUsIUWqXxqw47uGjimeT4Qgkz/XUfwoau08+fgvKA==",
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz",
+      "integrity": "sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -1722,9 +1722,9 @@
       }
     },
     "@types/koa__cors": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-3.0.1.tgz",
-      "integrity": "sha512-loqZNXliley8kncc4wrX9KMqLGN6YfiaO3a3VFX+yVkkXJwOrZU4lipdudNjw5mFyC+5hd7h9075hQWcVVpeOg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-3.0.2.tgz",
+      "integrity": "sha512-gBetQR0DJ9JTG1YQoW33BADHCrDPJGiJUKUUcEPJwW1A2unzpIMhorEpXB6eMaaXTaqHLemcGnq3RmH9XaryRQ==",
       "dev": true,
       "requires": {
         "@types/koa": "*"
@@ -1749,9 +1749,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.25.tgz",
-      "integrity": "sha512-okMqUHqrMlGOxfDZliX1yFX5MV6qcd5PpRz96XYtjkM0Ws/hwg23FMUqt6pETrVRZS+EKUB5HY19mmo54EuQbA==",
+      "version": "14.11.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+      "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
       "dev": true
     },
     "@types/path-is-inside": {
@@ -1761,9 +1761,9 @@
       "dev": true
     },
     "@types/qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ==",
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
+      "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==",
       "dev": true
     },
     "@types/range-parser": {
@@ -1921,14 +1921,14 @@
       }
     },
     "browserslist": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.2.tgz",
-      "integrity": "sha512-HI4lPveGKUR0x2StIz+2FXfDk9SfVMrxn6PLh1JeGUwcuoDkdKZebWiyLRJ68iIPDpMI4JLVDf7S7XzslgWOhw==",
+      "version": "4.14.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.5.tgz",
+      "integrity": "sha512-Z+vsCZIvCBvqLoYkBFTwEYH3v5MCQbsAjp50ERycpOjnPmolg1Gjy4+KaWWpm8QOJt9GHkhdqAl14NpCX73CWA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001125",
-        "electron-to-chromium": "^1.3.564",
-        "escalade": "^3.0.2",
+        "caniuse-lite": "^1.0.30001135",
+        "electron-to-chromium": "^1.3.571",
+        "escalade": "^3.1.0",
         "node-releases": "^1.1.61"
       }
     },
@@ -1980,13 +1980,13 @@
       }
     },
     "camel-case": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
+      "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
+        "pascal-case": "^3.1.1",
+        "tslib": "^1.10.0"
       }
     },
     "camelcase": {
@@ -2008,9 +2008,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001125",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001125.tgz",
-      "integrity": "sha512-9f+r7BW8Qli917mU3j0fUaTweT3f3vnX/Lcs+1C73V+RADmFme+Ih0Br8vONQi3X0lseOe6ZHfsZLCA8MSjxUA==",
+      "version": "1.0.30001142",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001142.tgz",
+      "integrity": "sha512-pDPpn9ankEpBFZXyCv2I4lh1v/ju+bqb78QfKf+w9XgDAFWBwSYPswXqprRdrgQWK0wQnpIbfwRjNHO1HWqvoQ==",
       "dev": true
     },
     "chalk": {
@@ -2128,9 +2128,9 @@
       }
     },
     "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "dev": true
     },
     "commondir": {
@@ -2238,12 +2238,12 @@
       "dev": true
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
       "dev": true,
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "deep-equal": {
@@ -2297,10 +2297,20 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
+    "dot-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
+      "integrity": "sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      }
+    },
     "duplexer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
     },
     "dynamic-import-polyfill": {
@@ -2316,9 +2326,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.566",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.566.tgz",
-      "integrity": "sha512-V0fANdGN7waOE0tvCDhjf1vqPRevG3eo0asYm42c4t1qmZSunlnUuWQDxglUi9wDpbKQlGIttMJ+2DYpRwvYRA==",
+      "version": "1.3.576",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.576.tgz",
+      "integrity": "sha512-uSEI0XZ//5ic+0NdOqlxp0liCD44ck20OAGyLMSymIWTEAtHKVJi6JM18acOnRgUgX7Q65QqnI+sNncNvIy8ew==",
       "dev": true
     },
     "encodeurl": {
@@ -2337,29 +2347,29 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.0-next.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
-      "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+      "version": "1.18.0-next.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+      "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
+        "is-callable": "^1.2.2",
         "is-negative-zero": "^2.0.0",
         "is-regex": "^1.1.1",
         "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
+        "object.assign": "^4.1.1",
         "string.prototype.trimend": "^1.0.1",
         "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-dev-server": {
-      "version": "1.57.4",
-      "resolved": "https://registry.npmjs.org/es-dev-server/-/es-dev-server-1.57.4.tgz",
-      "integrity": "sha512-GNstq4VeNmkon9W4dABCC3e3540cWVmhsnO4d8axBSgk0D4HQH/t2NqM4o9Qvq4/z9NMAqW1CazmvuFdl8oqKg==",
+      "version": "1.57.6",
+      "resolved": "https://registry.npmjs.org/es-dev-server/-/es-dev-server-1.57.6.tgz",
+      "integrity": "sha512-yuxmKsAqN1r2Q6NQtTPGNHvU4XkuOpdCWgJHvfFgNTaNd0+b5XZtpWuU4APhh08G1EWG5rzy8D35VH5xInJo6g==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.1",
@@ -2374,7 +2384,7 @@
         "@babel/plugin-transform-template-literals": "^7.8.3",
         "@babel/preset-env": "^7.9.0",
         "@koa/cors": "^3.1.0",
-        "@open-wc/building-utils": "^2.18.1",
+        "@open-wc/building-utils": "^2.18.2",
         "@rollup/plugin-node-resolve": "^7.1.1",
         "@rollup/pluginutils": "^3.0.0",
         "@types/babel__core": "^7.1.3",
@@ -2418,7 +2428,7 @@
         "open": "^7.0.3",
         "parse5": "^5.1.1",
         "path-is-inside": "^1.0.2",
-        "polyfills-loader": "^1.7.1",
+        "polyfills-loader": "^1.7.2",
         "portfinder": "^1.0.21",
         "rollup": "^2.7.2",
         "strip-ansi": "^5.2.0",
@@ -2476,9 +2486,9 @@
       }
     },
     "escalade": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
-      "integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
+      "integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==",
       "dev": true
     },
     "escape-html": {
@@ -2646,19 +2656,19 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
-    "html-minifier": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",
-      "integrity": "sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==",
+    "html-minifier-terser": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
+      "integrity": "sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==",
       "dev": true,
       "requires": {
-        "camel-case": "^3.0.0",
-        "clean-css": "^4.2.1",
-        "commander": "^2.19.0",
+        "camel-case": "^4.1.1",
+        "clean-css": "^4.2.3",
+        "commander": "^4.1.1",
         "he": "^1.2.0",
-        "param-case": "^2.1.1",
+        "param-case": "^3.0.3",
         "relateurl": "^0.2.7",
-        "uglify-js": "^3.5.1"
+        "terser": "^4.6.3"
       }
     },
     "http-assert": {
@@ -2748,9 +2758,9 @@
       }
     },
     "is-callable": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.1.tgz",
-      "integrity": "sha512-wliAfSzx6V+6WfMOmus1xy0XvSgf/dlStkvTfq7F0g4bOIW0PSUbnyse3NhDwdyYS1ozfUtAAySqTws3z9Eqgg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
       "dev": true
     },
     "is-date-object": {
@@ -3039,9 +3049,9 @@
       }
     },
     "lezer": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/lezer/-/lezer-0.10.3.tgz",
-      "integrity": "sha512-On3+Q+LBw+Ng756tmlGnst9ZqH7qMviBJF4V15hHgRAoyBIzPvBQRmPMdvDLK+D0pXjIS4QnojiqeBM3Isu5/w==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/lezer/-/lezer-0.10.4.tgz",
+      "integrity": "sha512-ltjjt6A0TRUMFxjgAn/Vnxnj7Mv0D9UFHH2hHiNAjT72incbeKheuuJ77GUaAD+D9jC8NasGuFwUx+zwvi+wxg==",
       "requires": {
         "lezer-tree": "^0.10.0"
       }
@@ -3100,17 +3110,17 @@
       "integrity": "sha512-77hwilCuD4azYqwazv4A6EL7mKiSPcqgJV4V173hLV3UkAKa6/smNHeROhIzzWHLU6Y5qtR1mRf22RFzE3fVrg=="
     },
     "lit-element": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.3.1.tgz",
-      "integrity": "sha512-tOcUAmeO3BzwiQ7FGWdsshNvC0HVHcTFYw/TLIImmKwXYoV0E7zCBASa8IJ7DiP4cen/Yoj454gS0qqTnIGsFA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.4.0.tgz",
+      "integrity": "sha512-pBGLglxyhq/Prk2H91nA0KByq/hx/wssJBQFiYqXhGDvEnY31PRGYf1RglVzyLeRysu0IHm2K0P196uLLWmwFg==",
       "requires": {
         "lit-html": "^1.1.1"
       }
     },
     "lit-html": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.2.1.tgz",
-      "integrity": "sha512-GSJHHXMGLZDzTRq59IUfL9FCdAlGfqNp/dEa7k7aBaaWD+JKaCjsAk9KYm2V12ItonVaYx2dprN66Zdm1AuBTQ=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.3.0.tgz",
+      "integrity": "sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q=="
     },
     "lodash": {
       "version": "4.17.20",
@@ -3152,10 +3162,13 @@
       }
     },
     "lower-case": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+      "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.10.0"
+      }
     },
     "lru-cache": {
       "version": "5.1.1",
@@ -3250,12 +3263,13 @@
       "dev": true
     },
     "no-case": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+      "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
       "dev": true,
       "requires": {
-        "lower-case": "^1.1.1"
+        "lower-case": "^2.0.1",
+        "tslib": "^1.10.0"
       }
     },
     "node-cleanup": {
@@ -3331,9 +3345,9 @@
       "dev": true
     },
     "open": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.2.1.tgz",
-      "integrity": "sha512-xbYCJib4spUdmcs0g/2mK1nKo/jO2T7INClWd/beL7PFkXRWgr8B23ssDHX/USPn2M2IjDR5UdpYs6I67SnTSA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.3.0.tgz",
+      "integrity": "sha512-mgLwQIx2F/ye9SmbrUkurZCnkoXyXyu9EbHtJZrICjVAJfyMArdHp3KkixGdZx1ZHFPNIwl0DDM1dFFqXbTLZw==",
       "dev": true,
       "requires": {
         "is-docker": "^2.0.0",
@@ -3347,12 +3361,13 @@
       "dev": true
     },
     "param-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
-      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
+      "integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0"
+        "dot-case": "^3.0.3",
+        "tslib": "^1.10.0"
       }
     },
     "parse5": {
@@ -3366,6 +3381,16 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true
+    },
+    "pascal-case": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
+      "integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -3407,20 +3432,19 @@
       "dev": true
     },
     "polyfills-loader": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/polyfills-loader/-/polyfills-loader-1.7.1.tgz",
-      "integrity": "sha512-+cClGOZNQtWVedt2a2Ku9r6ejfnhQFbuaSPtlaGLl2R9ESWaJNoq8r29d0BTpAgrEX/xXsoh2YHgamNugW6Ahw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/polyfills-loader/-/polyfills-loader-1.7.2.tgz",
+      "integrity": "sha512-MUo8OXTDOVcGOf+WbgLiolS9cJquLQWHh3lAQKCaOxGv8Z43IJmJqmwGa6r/wfOnF4aH3f3WwHXfZAi/JjiAgg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.1",
-        "@open-wc/building-utils": "^2.18.1",
+        "@open-wc/building-utils": "^2.18.2",
         "@webcomponents/webcomponentsjs": "^2.4.0",
         "abortcontroller-polyfill": "^1.4.0",
         "core-js-bundle": "^3.6.0",
         "deepmerge": "^4.2.2",
         "dynamic-import-polyfill": "^0.1.1",
         "es-module-shims": "^0.4.6",
-        "html-minifier": "^4.0.0",
         "intersection-observer": "^0.7.0",
         "parse5": "^5.1.1",
         "regenerator-runtime": "^0.13.3",
@@ -3453,9 +3477,9 @@
       }
     },
     "prettier": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
       "dev": true
     },
     "ps-tree": {
@@ -3535,9 +3559,9 @@
       }
     },
     "regexpu-core": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
-      "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+      "integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
       "dev": true,
       "requires": {
         "regenerate": "^1.4.0",
@@ -3638,9 +3662,9 @@
       }
     },
     "rollup": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.23.0.tgz",
-      "integrity": "sha512-vLNmZFUGVwrnqNAJ/BvuLk1MtWzu4IuoqsH9UWK5AIdO3rt8/CSiJNvPvCIvfzrbNsqKbNzPAG1V2O4eTe2XZg==",
+      "version": "2.28.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.28.2.tgz",
+      "integrity": "sha512-8txbsFBFLmm9Xdt4ByTOGa9Muonmc8MfNjnGAR8U8scJlF1ZW7AgNZa7aqBXaKtlvnYP/ab++fQIq9dB9NWUbg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"
@@ -3801,20 +3825,20 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -3832,20 +3856,20 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -3862,9 +3886,9 @@
       }
     },
     "style-mod": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-2.3.0.tgz",
-      "integrity": "sha512-/cIxCzlhyR+6dvlsl3U9IO0cLQBYPkf7GRzyomiZQhvoW+WB6LRFymxMdNaiixal6uxhwMrO5MzitqpHQAtLGg=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-2.3.1.tgz",
+      "integrity": "sha512-mSHi5AHMotMZct9AQZJRrDRDFE+hqquWyV5jw026EgNvE8+y6qXtTZscOY455E/Io87c/9bnROmv2AMjA9u8pA=="
     },
     "supports-color": {
       "version": "5.5.0",
@@ -3876,9 +3900,9 @@
       }
     },
     "systemjs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-6.5.1.tgz",
-      "integrity": "sha512-N3Qx2Ro84vqyrjY+lJr9HlAiMz6hs3YiwDZljYLNPQu8yJ+NaETYU0ijqKvAdc/khulbTc2IAq9O0VLeRLSRnw==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-6.6.1.tgz",
+      "integrity": "sha512-Niw/DZwTPmdLGC0CCe+n/MdRu927XyN/jzxKZyU6tUfeNqGQlxO5oVXuVMsJHxPO2cnXyHh0/zIGdXaocOMLVQ==",
       "dev": true
     },
     "table-layout": {
@@ -3918,6 +3942,12 @@
         "source-map-support": "~0.5.12"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4052,12 +4082,6 @@
       "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
       "dev": true
     },
-    "uglify-js": {
-      "version": "3.10.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.4.tgz",
-      "integrity": "sha512-kBFT3U4Dcj4/pJ52vfjCSfyLyvG9VYYuGYPmrPvAxRw/i7xHiT4VvCev+uiEMcEEiu6UNB6KgWmGtSUYIWScbw==",
-      "dev": true
-    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -4084,12 +4108,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
       "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
-      "dev": true
-    },
-    "upper-case": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
     },
     "useragent": {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
   "module": "lib/code-sample-editor.js",
   "main": "lib/code-sample-editor.js",
   "scripts": {
-    "build": "npm run build:lib && npm run bundle",
+    "build": "npm run build:lib && npm run build:sw && npm run bundle",
     "build:lib": "tsc --build",
+    "build:sw": "tsc --build src/service-worker",
     "bundle": "rollup -c rollup.config.js",
-    "watch": "tsc --build --watch & rollup -c rollup.config.js -w",
+    "watch": "npm run build:lib -- --watch & npm run build:sw -- --watch & rollup -c rollup.config.js -w",
     "serve": "es-dev-server --node-resolve --event-stream=false",
-    "dev": "npm run watch & npm run serve",
+    "dev": "npm run watch & npm run serve -- --open=demo/",
     "format": "prettier src/**/*.ts --write",
     "prepublishOnly": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
   },
   "dependencies": {
     "@codemirror/next": "^0.12.0",
-    "@material/mwc-button": "^0.19.0-canary.615d861d.0",
-    "@material/mwc-icon-button": "^0.19.0-canary.615d861d.0",
-    "@material/mwc-tab": "^0.19.0-canary.615d861d.0",
-    "@material/mwc-tab-bar": "^0.19.0-canary.615d861d.0",
-    "@material/mwc-textfield": "^0.19.0-canary.615d861d.0",
+    "@material/mwc-button": "=0.19.0-canary.615d861d.0",
+    "@material/mwc-icon-button": "=0.19.0-canary.615d861d.0",
+    "@material/mwc-tab": "=0.19.0-canary.615d861d.0",
+    "@material/mwc-tab-bar": "=0.19.0-canary.615d861d.0",
+    "@material/mwc-textfield": "=0.19.0-canary.615d861d.0",
     "comlink": "^4.3.0",
     "lit-element": "^2.3.1",
     "lit-html": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   },
   "dependencies": {
     "@codemirror/next": "^0.12.0",
-    "@material/mwc-button": "^0.18.0",
-    "@material/mwc-icon-button": "^0.18.0",
-    "@material/mwc-tab": "^0.18.0",
-    "@material/mwc-tab-bar": "^0.18.0",
-    "@material/mwc-textfield": "^0.18.0",
+    "@material/mwc-button": "^0.19.0-canary.615d861d.0",
+    "@material/mwc-icon-button": "^0.19.0-canary.615d861d.0",
+    "@material/mwc-tab": "^0.19.0-canary.615d861d.0",
+    "@material/mwc-tab-bar": "^0.19.0-canary.615d861d.0",
+    "@material/mwc-textfield": "^0.19.0-canary.615d861d.0",
     "comlink": "^4.3.0",
     "lit-element": "^2.3.1",
     "lit-html": "^1.2.1"

--- a/src/lib/code-sample-editor.ts
+++ b/src/lib/code-sample-editor.ts
@@ -50,6 +50,20 @@ declare global {
   }
 }
 
+// Hack to workaround Safari crashing and reloading the entire browser tab
+// whenever an <mwc-tab> is clicked to switch files, because of a bug relating
+// to delegatesFocus and shadow roots.
+//
+// https://bugs.webkit.org/show_bug.cgi?id=215732
+// https://github.com/material-components/material-components-web-components/issues/1720
+import {Tab} from '@material/mwc-tab';
+((Tab.prototype as unknown) as {
+  createRenderRoot: Tab['createRenderRoot'];
+  attachShadow: Tab['attachShadow'];
+}).createRenderRoot = function () {
+  return this.attachShadow({mode: 'open', delegatesFocus: false});
+};
+
 // Each <code-sample-editor> has a unique session ID used to scope requests
 // from the preview iframes.
 const sessions = new Set<string>();


### PR DESCRIPTION
- Add hacky workaround for Safari bug (https://bugs.webkit.org/show_bug.cgi?id=215732) to prevent the browser tab from hard-crashing whenever an `<mwc-tab>` is clicked to change files. (Workaround suggested in https://github.com/material-components/material-components-web-components/issues/1720).

- Update to the latest MWC canary versions to pick up https://github.com/material-components/material-components-web-components/issues/1867, which partly fixes Safari.

- Actually build the service worker, since that wasn't happening before.

- Use absolute paths for the demo project files, since otherwise going to `localhost:8080/demo` will error confusingly while `localhost:8080/demo/` works.

Fixes https://github.com/PolymerLabs/code-sample-editor/issues/38