### PR TITLE
Release 0.1.0-pre.3 + misc changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+<!--
+   PRs should document their user-visible changes (if any) in the
+   Unreleased section, uncommenting the header as necessary.
+-->
+
+<!-- ## [X.Y.Z] - YYYY-MM-DD -->
+<!-- ## Unreleased -->
+<!-- ### Changed -->
+<!-- ### Added -->
+<!-- ### Fixed -->
+<!-- ### Removed -->
+
+## [0.1.0-pre.3] - 2020-10-05
+
+### Fixed
+- Fixed missing CodeMirror styles on Firefox and Safari.
+- Fixed Safari crashes in `<mwc-tab>` code.
+
+## [0.1.0-pre.2] - 2020-09-12
+
+### Fixed
+- Fix extra/missing files.
+
+## [0.1.0-pre.1] - 2020-09-12
+- Initial release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1438,30 +1438,37 @@
       }
     },
     "@rollup/plugin-commonjs": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-14.0.0.tgz",
-      "integrity": "sha512-+PSmD9ePwTAeU106i9FRdc+Zb3XUWyW26mo5Atr2mk82hor8+nPwkztEjFo8/B1fJKfaQDg9aM2bzQkjhi7zOw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-15.1.0.tgz",
+      "integrity": "sha512-xCQqz4z/o0h2syQ7d9LskIMvBSH4PX5PjYdpSSvgS+pQik3WahkQVNWg3D8XJeYjZoVWnIUQYDghuEMRGrmQYQ==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "^3.0.8",
+        "@rollup/pluginutils": "^3.1.0",
         "commondir": "^1.0.1",
-        "estree-walker": "^1.0.1",
-        "glob": "^7.1.2",
-        "is-reference": "^1.1.2",
-        "magic-string": "^0.25.2",
-        "resolve": "^1.11.0"
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.1.tgz",
+          "integrity": "sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==",
+          "dev": true
+        }
       }
     },
     "@rollup/plugin-node-resolve": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-8.4.0.tgz",
-      "integrity": "sha512-LFqKdRLn0ShtQyf6SBYO69bGE1upV6wUhBX0vFOUnLAyzx5cwp8svA0eHUnu8+YU57XOkrMtfG63QOpQx25pHQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-9.0.0.tgz",
+      "integrity": "sha512-gPz+utFHLRrd41WMP13Jq5mqqzHL3OXrfj3/MkSyB6UBIcuNt9j60GCbarzMzdf1VHFpOxfQh/ez7wyadLMqkg==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
         "@types/resolve": "1.17.1",
         "builtin-modules": "^3.1.0",
-        "deep-freeze": "^0.0.1",
         "deepmerge": "^4.2.2",
         "is-module": "^1.0.0",
         "resolve": "^1.17.0"
@@ -2256,12 +2263,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true
-    },
-    "deep-freeze": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
-      "integrity": "sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ=",
       "dev": true
     },
     "deepmerge": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4071,9 +4071,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
       "dev": true
     },
     "typical": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "code-sample-editor",
-  "version": "0.1.0-pre.1",
+  "version": "0.1.0-pre.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2008,9 +2008,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001142",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001142.tgz",
-      "integrity": "sha512-pDPpn9ankEpBFZXyCv2I4lh1v/ju+bqb78QfKf+w9XgDAFWBwSYPswXqprRdrgQWK0wQnpIbfwRjNHO1HWqvoQ==",
+      "version": "1.0.30001143",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001143.tgz",
+      "integrity": "sha512-p/PO5YbwmCpBJPxjOiKBvAlUPgF8dExhfEpnsH+ys4N/791WHrYrGg0cyHiAURl5hSbx5vIcjKmQAP6sHDYH3w==",
       "dev": true
     },
     "chalk": {
@@ -2367,9 +2367,9 @@
       }
     },
     "es-dev-server": {
-      "version": "1.57.6",
-      "resolved": "https://registry.npmjs.org/es-dev-server/-/es-dev-server-1.57.6.tgz",
-      "integrity": "sha512-yuxmKsAqN1r2Q6NQtTPGNHvU4XkuOpdCWgJHvfFgNTaNd0+b5XZtpWuU4APhh08G1EWG5rzy8D35VH5xInJo6g==",
+      "version": "1.57.7",
+      "resolved": "https://registry.npmjs.org/es-dev-server/-/es-dev-server-1.57.7.tgz",
+      "integrity": "sha512-ph90lCbyTvHsC/zbidIXvCYv+B1ZDzWhgG4RWKVT0FLD7t3LA2Ya8PIVcVWY/iVsYQNrIitPdi4mk/El2mEfkQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.1",
@@ -2428,7 +2428,7 @@
         "open": "^7.0.3",
         "parse5": "^5.1.1",
         "path-is-inside": "^1.0.2",
-        "polyfills-loader": "^1.7.2",
+        "polyfills-loader": "^1.7.3",
         "portfinder": "^1.0.21",
         "rollup": "^2.7.2",
         "strip-ansi": "^5.2.0",
@@ -3432,9 +3432,9 @@
       "dev": true
     },
     "polyfills-loader": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/polyfills-loader/-/polyfills-loader-1.7.2.tgz",
-      "integrity": "sha512-MUo8OXTDOVcGOf+WbgLiolS9cJquLQWHh3lAQKCaOxGv8Z43IJmJqmwGa6r/wfOnF4aH3f3WwHXfZAi/JjiAgg==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/polyfills-loader/-/polyfills-loader-1.7.3.tgz",
+      "integrity": "sha512-+Gc2MiQ/BDUVJ2uGjKZHK7OnursSVWs1nWi93KodwnkSA+W+oY8yNHZPOm+64vDda9nJXa/XMQqYCAO+RjBadg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.1",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,10 @@
   "module": "lib/code-sample-editor.js",
   "main": "lib/code-sample-editor.js",
   "scripts": {
-    "build": "npm run build:lib && npm run build:sw && npm run bundle",
+    "build": "npm run build:lib && npm run bundle",
     "build:lib": "tsc --build",
-    "build:sw": "tsc --build src/service-worker",
     "bundle": "rollup -c rollup.config.js",
-    "watch": "npm run build:lib -- --watch & npm run build:sw -- --watch & rollup -c rollup.config.js -w",
+    "watch": "npm run build:lib -- --watch & rollup -c rollup.config.js -w",
     "serve": "es-dev-server --node-resolve --event-stream=false",
     "dev": "npm run watch & npm run serve -- --open=demo/",
     "format": "prettier src/**/*.ts --write",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-sample-editor",
-  "version": "0.1.0-pre.1",
+  "version": "0.1.0-pre.3",
   "description": "A multi-file code editor component with live preview",
   "type": "module",
   "module": "lib/code-sample-editor.js",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "rollup": "^2.21.0",
     "rollup-plugin-node-polyfills": "^0.2.1",
     "tsc-watch": "^4.2.3",
-    "typescript": "^3.9.7"
+    "typescript": "^4.0.3"
   },
   "dependencies": {
     "@codemirror/next": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "author": "The Polymer Authors",
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^14.0.0",
-    "@rollup/plugin-node-resolve": "^8.4.0",
+    "@rollup/plugin-commonjs": "^15.1.0",
+    "@rollup/plugin-node-resolve": "^9.0.0",
     "es-dev-server": "^1.57.4",
     "prettier": "^2.0.5",
     "rollup": "^2.21.0",

--- a/src/typescript-worker/typescript-worker.ts
+++ b/src/typescript-worker/typescript-worker.ts
@@ -39,7 +39,9 @@ const makeBareSpecifierTransformVisitor = (
       const {type, url} = resolveSpecifier(specifier, self.origin);
       if (type === 'bare') {
         const newNode = ts.getMutableClone(node);
-        newNode.moduleSpecifier = ts.createStringLiteral(url + '?module');
+        (newNode as {
+          moduleSpecifier: ts.ImportDeclaration['moduleSpecifier'];
+        }).moduleSpecifier = ts.createStringLiteral(url + '?module');
         return newNode;
       }
     }


### PR DESCRIPTION
- Release `0.1.0-pre.3`
- Add a changelog
- Bump dependencies (except for codemirror itself, since it doesn't compile after and I didn't look into it)
- Undo bad change from https://github.com/PolymerLabs/code-sample-editor/pull/42 that added `build:sw` script, I didn't realize that it _was_ getting built, using the new TypeScript project references feature.