### PR TITLE
Support layouts with a dedicated editor for each file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   or a direct reference to a `<code-sample-project>` element (which would allow
   the elements to live in different scopes).
 
+- The caret is now only displayed when an editor is on focus (previously it was
+  always displayed).
+
 ### Added
 
 - Add syntax highlighting for TypeScript files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,9 +68,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   getting and setting the currently selected file.
 - Add `noFilePicker` property (`no-file-picker` attribute) to
   `<code-sample-editor>` which disables the top file selection tab-bar.
-- Add `noLineNumbers` property (`no-line-numbers` attribute) to
-  `<code-sample-editor>` which disables the left-hand-side gutter with line
-  numbers.
+- Add `lineNumbers` property (`line-numbers` attribute) to
+  `<code-sample-editor>` which enables the left-hand-side gutter with line
+  numbers. This is on by default in `<code-sample>`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   getting and setting the currently selected file.
 - Add `noFilePicker` property (`no-file-picker` attribute) to
   `<code-sample-editor>` which disables the top file selection tab-bar.
+- Add `noLineNumbers` property (`no-line-numbers` attribute) to
+  `<code-sample-editor>` which disables the left-hand-side gutter with line
+  numbers.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add syntax highlighting for TypeScript files.
 - Add `filename` property/attribute to `<code-sample-editor>` which allows
   getting and setting the currently selected file.
+- Add `noFilePicker` property (`no-file-picker` attribute) to
+  `<code-sample-editor>` which disables the top file selection tab-bar.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Add syntax highlighting for TypeScript files.
+- Add `filename` property/attribute to `<code-sample-editor>` which allows
+  getting and setting the currently selected file.
 
 ### Fixed
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -87,6 +87,46 @@ export class MySecondElement extends LitElement {
     A demo for <code>&lt;mwc-button></code>.
   </p>
   <code-sample project-src="/demo/mwc-button/project.json"></code-sample>
+
+  <h2>Custom layout</h2>
+
+  By using <code>&lt;code-sample-project></code>,
+  <code>&lt;code-sample-editor></code>, and
+  <code>&lt;code-sample-preview></code> separately, you can create any kind of
+  layout:
+
+  <code-sample-project id="custom-project">
+    <script type="sample/html" filename="index.html">
+<!doctype html>
+<body>
+  <script src="./index.js">&lt;/script>
+</body>
+    </script>
+    <script type="sample/ts" filename="index.ts">
+document.body.textContent = 'Hello!';
+    </script>
+  </code-sample-project>
+
+  <h4>index.html</h4>
+  <code-sample-editor
+      project="custom-project"
+      filename="index.html"
+      no-file-picker
+      no-line-numbers>
+  </code-sample-editor>
+
+  <h4>index.ts</h4>
+  <code-sample-editor
+      project="custom-project"
+      filename="index.ts"
+      no-file-picker
+      no-line-numbers>
+  </code-sample-editor>
+
+  <h4>preview</h4>
+  <code-sample-preview
+      project="custom-project">
+  </code-sample-preview>
 </body>
 
 </html>

--- a/src/lib/code-sample-editor.ts
+++ b/src/lib/code-sample-editor.ts
@@ -96,6 +96,13 @@ export class CodeSampleEditor extends LitElement {
   @property({type: Boolean, attribute: 'no-file-picker'})
   noFilePicker = false;
 
+  /**
+   * If true, don't display the left-hand-side gutter with line numbers. Default
+   * false (visible).
+   */
+  @property({type: Boolean, attribute: 'no-line-numbers'})
+  noLineNumbers = false;
+
   @internalProperty()
   private _currentFileIndex?: number;
 
@@ -168,6 +175,7 @@ export class CodeSampleEditor extends LitElement {
         .type=${this._currentFile
           ? mimeTypeToTypeEnum(this._currentFile.contentType)
           : undefined}
+        .noLineNumbers=${this.noLineNumbers}
         @change=${this._onEdit}
       >
       </codemirror-editor>

--- a/src/lib/code-sample-editor.ts
+++ b/src/lib/code-sample-editor.ts
@@ -90,6 +90,12 @@ export class CodeSampleEditor extends LitElement {
   @property()
   filename?: string;
 
+  /**
+   * If true, don't display the top file-picker. Default: false (visible).
+   */
+  @property({type: Boolean, attribute: 'no-file-picker'})
+  noFilePicker = false;
+
   @internalProperty()
   private _currentFileIndex?: number;
 
@@ -142,18 +148,20 @@ export class CodeSampleEditor extends LitElement {
 
   render() {
     return html`
-      <mwc-tab-bar
-        .activeIndex=${this._currentFileIndex || 0}
-        @MDCTabBar:activated=${this._tabActivated}
-      >
-        ${this.files?.map((file) => {
-          const label = file.name.substring(file.name.lastIndexOf('/') + 1);
-          return html`<mwc-tab label=${label}></mwc-tab>`;
-        })}
-        ${this.enableAddFile
-          ? html`<mwc-icon-button icon="add"></mwc-icon-button>`
-          : nothing}
-      </mwc-tab-bar>
+      ${this.noFilePicker
+        ? ''
+        : html` <mwc-tab-bar
+            .activeIndex=${this._currentFileIndex || 0}
+            @MDCTabBar:activated=${this._tabActivated}
+          >
+            ${this.files?.map((file) => {
+              const label = file.name.substring(file.name.lastIndexOf('/') + 1);
+              return html`<mwc-tab label=${label}></mwc-tab>`;
+            })}
+            ${this.enableAddFile
+              ? html`<mwc-icon-button icon="add"></mwc-icon-button>`
+              : nothing}
+          </mwc-tab-bar>`}
 
       <codemirror-editor
         .value=${this._currentFile?.content}

--- a/src/lib/code-sample.ts
+++ b/src/lib/code-sample.ts
@@ -127,6 +127,7 @@ export class CodeSampleElement extends LitElement {
 
       <div id="editor">
         <code-sample-editor
+          .lineNumbers=${true}
           .project=${projectId}
           .enableAddFile=${this.enableAddFile}
         >

--- a/src/lib/codemirror-editor.ts
+++ b/src/lib/codemirror-editor.ts
@@ -92,11 +92,11 @@ export class CodeMirrorEditorElement extends LitElement {
   type: 'js' | 'ts' | 'html' | 'css' | undefined;
 
   /**
-   * If true, don't display the left-hand-side gutter with line numbers. Default
-   * false (visible).
+   * If true, display a left-hand-side gutter with line numbers. Default false
+   * (hidden).
    */
-  @property({type: Boolean, attribute: 'no-line-numbers'})
-  noLineNumbers = false;
+  @property({type: Boolean, attribute: 'line-numbers'})
+  lineNumbers = false;
 
   render() {
     return html` ${this._editorView?.dom} ${this._capturedCodeMirrorStyles} `;
@@ -113,7 +113,7 @@ export class CodeMirrorEditorElement extends LitElement {
     // This is called every time the value property is set externally, so that
     // we set up a fresh document with new state.
     const optionalPlugins = [];
-    if (!this.noLineNumbers) {
+    if (this.lineNumbers) {
       optionalPlugins.push(lineNumbers());
     }
     const view = new EditorView({

--- a/src/lib/codemirror-editor.ts
+++ b/src/lib/codemirror-editor.ts
@@ -58,6 +58,11 @@ export class CodeMirrorEditorElement extends LitElement {
     .cm-wrap {
       height: 100%;
     }
+
+    /* Hide the caret when editor is not focused. */
+    .cm-wrap:not(.cm-focused) .cm-cursor {
+      display: none;
+    }
   `;
 
   @internalProperty()

--- a/src/lib/codemirror-editor.ts
+++ b/src/lib/codemirror-editor.ts
@@ -86,6 +86,13 @@ export class CodeMirrorEditorElement extends LitElement {
   @property()
   type: 'js' | 'ts' | 'html' | 'css' | undefined;
 
+  /**
+   * If true, don't display the left-hand-side gutter with line numbers. Default
+   * false (visible).
+   */
+  @property({type: Boolean, attribute: 'no-line-numbers'})
+  noLineNumbers = false;
+
   render() {
     return html` ${this._editorView?.dom} ${this._capturedCodeMirrorStyles} `;
   }
@@ -100,6 +107,10 @@ export class CodeMirrorEditorElement extends LitElement {
   private _createView() {
     // This is called every time the value property is set externally, so that
     // we set up a fresh document with new state.
+    const optionalPlugins = [];
+    if (!this.noLineNumbers) {
+      optionalPlugins.push(lineNumbers());
+    }
     const view = new EditorView({
       dispatch: (t: Transaction) => {
         view.update([t]);
@@ -112,7 +123,6 @@ export class CodeMirrorEditorElement extends LitElement {
       state: EditorState.create({
         doc: this.value,
         extensions: [
-          lineNumbers(),
           highlightSpecialChars(),
           history(),
           drawSelection(),
@@ -126,6 +136,7 @@ export class CodeMirrorEditorElement extends LitElement {
             ...historyKeymap,
             ...commentKeymap,
           ]),
+          ...optionalPlugins,
         ],
       }),
       root: this.shadowRoot!,

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -23,7 +23,7 @@ export default {
   browsers: [
     playwrightLauncher({product: 'chromium'}),
     playwrightLauncher({product: 'firefox'}),
-    playwrightLauncher({product: 'webkit'}),
+    //playwrightLauncher({product: 'webkit'}),
   ],
   testFramework: {
     // https://mochajs.org/api/mocha


### PR DESCRIPTION
- Add `filename` property/attribute to `<code-sample-editor>` which allows  getting and setting the currently selected file.

- Add `noFilePicker` property (`no-file-picker` attribute) to  `<code-sample-editor>` which disables the top file selection `tab-bar`.

- Add `lineNumbers` property (`line-numbers` attribute) to  `<code-sample-editor>` and `<codemirror-editor>` which enables the left-hand-side gutter with line numbers. Off by default, but switched on in `<code-sample>`.

- The caret is now only displayed when an editor is focused (previously it was always displayed).

So for example, now you can do something like this:

```html
<code-sample-project id="custom-project">
  <script type="sample/html" filename="index.html">
    <!doctype html>
    <body>
      <script src="./index.js">&lt;/script>
    </body>
  </script>

  <script type="sample/ts" filename="index.ts">
    document.body.textContent = 'Hello!';
  </script>
</code-sample-project>

<h4>index.html</h4>
<code-sample-editor
    project="custom-project"
    filename="index.html"
    no-file-picker>
</code-sample-editor>

<h4>index.ts</h4>
<code-sample-editor
    project="custom-project"
    filename="index.ts"
    no-file-picker>
</code-sample-editor>

<h4>preview</h4>
<code-sample-preview
    project="custom-project">
</code-sample-preview>
```

Which will display like this:

![image](https://user-images.githubusercontent.com/48894/95503663-80f54480-0960-11eb-99ef-fc911d22386d.png)

Fixes https://github.com/PolymerLabs/code-sample-editor/issues/30