### PR TITLE
Add configurator UI for github.io

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -3,8 +3,7 @@ name: deploy-demo
 on:
   push:
     branches:
-      # TODO(aomarks) Switch to master once ready.
-      - configurator
+      - master
 
 jobs:
   test-and-deploy:

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,42 @@
+name: deploy-demo
+
+on:
+  push:
+    branches:
+      # TODO(aomarks) Switch to master once ready.
+      - configurator
+
+jobs:
+  test-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - name: NPM install
+        run: npm ci
+
+      - name: Build elements
+        run: npm run build
+
+      - name: Build configurator
+        run: npm run build:configurator
+
+      - name: Deploy to gh-pages
+        run: |
+          cp -r configurator/deploy ..
+          git fetch origin gh-pages --depth=1
+          git checkout --track origin/gh-pages
+          rm -rf *
+          mv ../deploy/* .
+          if [[ -n $(git status -s) ]]
+          then
+            git config user.name "$GITHUB_ACTOR (bot)"
+            git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+            git add -A
+            git commit -am "Deploy $GITHUB_SHA"
+            git push
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /lib/
 /service-worker/
 /shared/
+/configurator/lib/
+/configurator/deploy/
 /typescript-worker/
 service-worker.js
 typescript-worker.js

--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,8 @@
 /demo/
 /test/
 /src/test/
+/src/configurator/
+/configurator/
 *.tsbuildinfo
 .prettierrc.json
 rollup.config.js

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     "**/bundle": true
   },
   "editor.formatOnSave": true,
-  "files.insertFinalNewline": true
+  "files.insertFinalNewline": true,
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <title>Playground Elements Configurator</title>
+  <link rel=icon href=data:,>
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Mono&display=swap" rel="stylesheet">
+  <script type="module" src="./lib/playground-configurator.js"></script>
+  <style>
+    body {
+      margin: 0;
+      height: 100vh;
+    }
+    playground-configurator {
+      height: 100%;
+    }
+  </style>
+  <playground-configurator></playground-configurator>
+</body>
+</html>

--- a/configurator/project/index.html
+++ b/configurator/project/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <script type="module" src="./my-element.js"></script>
+  </head>
+  <body>
+    <div>Here are the contents:</div>
+    <my-element myNumber="5">
+      <div>Element is not upgraded</div>
+    </my-element>
+  </body>
+</html>

--- a/configurator/project/index.html
+++ b/configurator/project/index.html
@@ -4,9 +4,6 @@
     <script type="module" src="./my-element.js"></script>
   </head>
   <body>
-    <div>Here are the contents:</div>
-    <my-element myNumber="5">
-      <div>Element is not upgraded</div>
-    </my-element>
+    <my-element greet="World"></my-element>
   </body>
 </html>

--- a/configurator/project/my-element.ts
+++ b/configurator/project/my-element.ts
@@ -2,14 +2,10 @@ import {LitElement, html, property, customElement} from 'lit-element';
 
 @customElement('my-element')
 export class MyElement extends LitElement {
-  @property({type: Number})
-  myNumber?: number;
+  @property()
+  greet = 'nobody';
 
   render() {
-    return html`
-      <div>Here is ${this.myNumber}</div>
-      <div>And here is my second element:</div>
-      <my-second-element></my-second-element>
-    `;
+    return html`<p>Hello <b>${this.greet}</b>!</p>`;
   }
 }

--- a/configurator/project/my-element.ts
+++ b/configurator/project/my-element.ts
@@ -1,0 +1,15 @@
+import {LitElement, html, property, customElement} from 'lit-element';
+
+@customElement('my-element')
+export class MyElement extends LitElement {
+  @property({type: Number})
+  myNumber?: number;
+
+  render() {
+    return html`
+      <div>Here is ${this.myNumber}</div>
+      <div>And here is my second element:</div>
+      <my-second-element></my-second-element>
+    `;
+  }
+}

--- a/configurator/project/project.json
+++ b/configurator/project/project.json
@@ -1,0 +1,6 @@
+{
+  "files": {
+    "index.html": {},
+    "my-element.ts": {}
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8443,9 +8443,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "version": "4.1.0-dev.20201019",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.0-dev.20201019.tgz",
+      "integrity": "sha512-JydG7eBKDj2Kj2qOAJM41wFQ97HGi/qd4BfJOiLdC9Mj8PCnmjMuETAQoEjCI9x5TcMFyTyWU0whzSUfpfrelg==",
       "dev": true
     },
     "typical": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1930,6 +1930,25 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/fs-extra": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.1.tgz",
+      "integrity": "sha512-TcUlBem321DFQzBNuz8p0CLLKp0VvF/XH9E4KHNmgwyp4E3AfgI5cjiIVZWlbfThBop2qxFIh4+LeY6hVWWZ2w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/http-assert": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.1.tgz",
@@ -3381,6 +3400,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "colorette": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+      "dev": true
+    },
     "colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
@@ -4719,6 +4744,17 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -5508,6 +5544,12 @@
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
+    "is-plain-object": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
+      "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
+      "dev": true
+    },
     "is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -5695,6 +5737,15 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonparse": {
@@ -7534,6 +7585,37 @@
         "fsevents": "~2.1.2"
       }
     },
+    "rollup-plugin-copy": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.3.0.tgz",
+      "integrity": "sha512-euDjCUSBXZa06nqnwCNADbkAcYDfzwowfZQkto9K/TFhiH+QG7I4PUsEMwM9tDgomGWJc//z7KLW8t+tZwxADA==",
+      "dev": true,
+      "requires": {
+        "@types/fs-extra": "^8.0.1",
+        "colorette": "^1.1.0",
+        "fs-extra": "^8.1.0",
+        "globby": "10.0.1",
+        "is-plain-object": "^3.0.0"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+          "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.0.3",
+            "glob": "^7.1.3",
+            "ignore": "^5.1.1",
+            "merge2": "^1.2.3",
+            "slash": "^3.0.0"
+          }
+        }
+      }
+    },
     "rollup-plugin-filesize": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-filesize/-/rollup-plugin-filesize-9.0.2.tgz",
@@ -8521,6 +8603,12 @@
       "requires": {
         "imurmurhash": "^0.1.4"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   "scripts": {
     "build": "npm run build:lib && npm run bundle",
     "build:lib": "tsc --build",
+    "build:configurator": "rollup -c rollup.config.configurator.js",
     "bundle": "rollup -c rollup.config.js",
     "test": "wtr",
     "watch": "npm run build:lib -- --watch & rollup -c rollup.config.js -w",
-    "serve": "es-dev-server --node-resolve --event-stream=false",
-    "dev": "npm run watch & npm run serve -- --open=demo/",
+    "serve": "es-dev-server --node-resolve --watch --open=configurator/",
     "format": "prettier src/**/*.ts --write",
     "prepublishOnly": "npm run build"
   },
@@ -32,6 +32,7 @@
     "google_modes": "git+https://github.com/codemirror/google-modes.git#57b26bb0e76ca5d3b83b12faf13ce1054d34bddf",
     "prettier": "^2.0.5",
     "rollup": "^2.21.0",
+    "rollup-plugin-copy": "^3.3.0",
     "rollup-plugin-lit-css": "^2.0.5",
     "rollup-plugin-node-polyfills": "^0.2.1",
     "rollup-plugin-summary": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "rollup-plugin-summary": "^1.2.3",
     "rollup-plugin-terser": "^7.0.2",
     "tsc-watch": "^4.2.3",
-    "typescript": "^4.0.3"
+    "typescript": "^4.1.0-beta"
   },
   "dependencies": {
     "@material/mwc-icon-button": "=0.19.0-canary.615d861d.0",

--- a/rollup.config.configurator.js
+++ b/rollup.config.configurator.js
@@ -1,0 +1,50 @@
+import resolve from '@rollup/plugin-node-resolve';
+import {terser} from 'rollup-plugin-terser';
+import copy from 'rollup-plugin-copy';
+
+export default [
+  {
+    input: 'configurator/lib/playground-configurator.js',
+    output: {
+      file: 'configurator/deploy/lib/playground-configurator.js',
+      format: 'esm',
+    },
+    plugins: [
+      resolve(),
+      terser({
+        warnings: true,
+        ecma: 2017,
+        compress: {
+          unsafe: true,
+          passes: 2,
+        },
+        output: {
+          comments: 'some',
+        },
+        mangle: {
+          properties: false,
+        },
+      }),
+      copy({
+        targets: [
+          {
+            src: 'configurator/index.html',
+            dest: 'configurator/deploy/',
+          },
+          {
+            src: 'configurator/project',
+            dest: 'configurator/deploy/',
+          },
+          {
+            src: 'typescript-worker.js',
+            dest: 'configurator/deploy/',
+          },
+          {
+            src: 'service-worker.js',
+            dest: 'configurator/deploy/',
+          },
+        ],
+      }),
+    ],
+  },
+];

--- a/src/configurator/lib/knobs.ts
+++ b/src/configurator/lib/knobs.ts
@@ -1,0 +1,245 @@
+/**
+ * @license
+ * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+ /**
+  * This kinda turned into something like storybook.js and similar. Maybe we
+  * should just use another library.
+  */
+
+interface BaseKnob<Id extends string, T> {
+  id: Id;
+  label: string;
+  section: string;
+  default: T;
+  cssProperty?: string;
+  formatCss?: (value: T) => string;
+  htmlAttribute?: string;
+}
+
+interface CheckboxKnob<Id extends string> extends BaseKnob<Id, boolean> {
+  type: 'checkbox';
+}
+
+interface SliderKnob<Id extends string> extends BaseKnob<Id, number> {
+  type: 'slider';
+  min: number;
+  max: number;
+}
+
+interface ColorKnob<Id extends string> extends BaseKnob<Id, string> {
+  type: 'color';
+  unsetLabel?: string;
+}
+
+interface SelectKnob<Id extends string, T extends string>
+  extends BaseKnob<Id, T> {
+  type: 'select';
+  options: ReadonlyArray<T>;
+}
+
+function checkbox<Id extends string>(
+  def: Omit<CheckboxKnob<Id>, 'type'>
+): CheckboxKnob<Id> {
+  return {type: 'checkbox', ...def};
+}
+
+function slider<Id extends string>(
+  def: Omit<SliderKnob<Id>, 'type'>
+): SliderKnob<Id> {
+  return {type: 'slider', ...def};
+}
+
+function color<Id extends string>(
+  def: Omit<ColorKnob<Id>, 'type'>
+): ColorKnob<Id> {
+  return {type: 'color', ...def};
+}
+
+function select<Id extends string, T extends string>(
+  def: Omit<SelectKnob<Id, T>, 'type'>
+): SelectKnob<Id, T> {
+  return {type: 'select', ...def};
+}
+
+const pixels = (value: number) => value + 'px';
+
+export const knobs = [
+  // code editor
+  select({
+    id: 'theme',
+    label: 'Theme',
+    section: 'code editor',
+    htmlAttribute: 'theme',
+    options: ['default', 'monokai'],
+    default: 'default',
+  }),
+  select({
+    id: 'fontFamily',
+    label: 'Font',
+    section: 'code editor',
+    cssProperty: '--playground-code-font-family',
+    options: ['monospace', 'Roboto Mono', 'Source Code Pro', 'Ubuntu Mono'],
+    formatCss: (value: string | number | boolean) => {
+      if (value !== 'monospace') {
+        return `${value}, monospace`;
+      }
+      return value;
+    },
+    default: 'monospace',
+  }),
+  slider({
+    id: 'fontSize',
+    label: 'Font size',
+    section: 'code editor',
+    cssProperty: '--playground-code-font-size',
+    formatCss: pixels,
+    min: 1,
+    max: 30,
+    default: 14,
+  }),
+  checkbox({
+    id: 'lineNumbers',
+    label: 'Line numbers',
+    section: 'code editor',
+    default: false,
+    htmlAttribute: 'line-numbers',
+  }),
+  color({
+    id: 'editorBackground',
+    label: 'Background',
+    section: 'code editor',
+    cssProperty: '--playground-editor-background-color',
+    default: '',
+    unsetLabel: 'From theme',
+  }),
+
+  // file picker
+  color({
+    id: 'filePickerBackground',
+    label: 'Background',
+    cssProperty: '--playground-file-picker-background-color',
+    default: '#ffffff',
+    section: 'file picker',
+  }),
+  color({
+    id: 'filePickerForeground',
+    label: 'Foreground',
+    cssProperty: '--playground-file-picker-foreground-color',
+    default: '#000000',
+    section: 'file picker',
+  }),
+
+  // preview toolbar
+  color({
+    id: 'previewToolbarBackground',
+    label: 'Background',
+    cssProperty: '--playground-preview-toolbar-background-color',
+    default: '#ffffff',
+    section: 'preview toolbar',
+  }),
+  color({
+    id: 'previewToolbarForeground',
+    label: 'Foreground',
+    cssProperty: '--playground-preview-toolbar-foreground-color',
+    default: '#444444',
+    section: 'preview toolbar',
+  }),
+
+  // general
+  checkbox({
+    id: 'borders',
+    label: 'Borders',
+    cssProperty: '--playground-border',
+    formatCss: (value: string | number | boolean) =>
+      value ? '1px solid #ddd' : 'none',
+    default: true,
+    section: 'general',
+  }),
+  color({
+    id: 'highlight',
+    label: 'Highlight',
+    cssProperty: '--playground-highlight-color',
+    default: '#6200ee',
+    section: 'general',
+  }),
+  slider({
+    id: 'radius',
+    label: 'Radius',
+    cssProperty: 'border-radius',
+    formatCss: pixels,
+    min: 0,
+    max: 30,
+    default: 0,
+    section: 'general',
+  }),
+  slider({
+    id: 'barHeight',
+    label: 'Bar height',
+    cssProperty: '--playground-bar-height',
+    formatCss: pixels,
+    min: 10,
+    max: 100,
+    default: 35,
+    section: 'general',
+  }),
+  color({
+    id: 'pageBackground',
+    label: 'Page background',
+    default: '#cccccc',
+    section: 'general',
+  }),
+] as const;
+
+export type Knob = typeof knobs[number];
+export type KnobId = Knob['id'];
+
+type KnobsById = {[K in Knob as K['id']]: K};
+export const knobsById = {} as KnobsById;
+export const knobsBySection = {} as {[section: string]: Knob[]};
+for (const knob of knobs) {
+  // Cast to an arbitrary specific Knob type here because TypeScript isn't quite
+  // clever enough to know that the id will match the type.
+  knobsById[(knob as typeof knobs[0]).id] = knob as typeof knobs[0];
+  let catArr = knobsBySection[knob.section];
+  if (catArr === undefined) {
+    catArr = knobsBySection[knob.section] = [];
+  }
+  catArr.push(knob);
+}
+export const knobIds = Object.keys(knobsById) as KnobId[];
+export const knobSectionNames = Object.keys(knobsBySection);
+
+export type KnobsOfType<T extends Knob['type']> = Exclude<
+  {
+    [K in Knob as K['id']]: K extends {type: T} ? K : never;
+  }[KnobId],
+  never
+>;
+
+export type KnobValueType<T extends KnobId> = KnobsById[T]['default'];
+
+export class KnobValues {
+  private values = new Map<KnobId, Knob['default']>();
+
+  getValue<T extends KnobId>(id: T): KnobValueType<T> {
+    if (this.values.has(id)) {
+      return this.values.get(id) as any;
+    }
+    return knobsById[id].default as any;
+  }
+
+  setValue<T extends KnobId>(id: T, value: KnobValueType<T>) {
+    this.values.set(id, value);
+  }
+}

--- a/src/configurator/lib/playground-configurator.ts
+++ b/src/configurator/lib/playground-configurator.ts
@@ -1,0 +1,478 @@
+/**
+ * @license
+ * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {LitElement, customElement, html, css} from 'lit-element';
+
+import '../../lib/code-sample.js';
+import '../../lib/codemirror-editor.js';
+import {
+  Knob,
+  KnobId,
+  KnobValueType,
+  KnobValues,
+  KnobsOfType,
+  knobIds,
+  knobSectionNames,
+  knobs,
+  knobsById,
+  knobsBySection,
+} from './knobs.js';
+
+/**
+ * A configurator for the playground-* elements.
+ */
+@customElement('playground-configurator')
+export class PlaygroundConfigurator extends LitElement {
+  static styles = css`
+    :host {
+      display: flex;
+      font-family: Roboto, Arial, Helvetica, sans-serif;
+    }
+
+    #lhs {
+      width: 260px;
+      overflow-y: auto;
+      border-right: 1px solid #ccc;
+      box-shadow: -2px 0 6px 0px rgb(0 0 0 / 50%);
+      z-index: 1;
+      color: #424242;
+      font-size: 13px;
+    }
+
+    #rhs {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      overflow: auto;
+    }
+
+    #container {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      flex: 1;
+      /* To position the GitHub cat corner. */
+      position: relative;
+    }
+
+    code-sample {
+      flex: 1;
+      margin: 50px;
+      max-width: 900px;
+    }
+
+    #code {
+      display: flex;
+      flex-wrap: wrap;
+      border-top: 1px solid #ccc;
+      padding: 10px;
+      --playground-code-font-family: 'Roboto Mono', monospace;
+      --playground-code-font-size: 12px;
+      --playground-editor-background-color: #f7f7f7;
+      background-color: #f7f7f7;
+    }
+
+    h3 {
+      color: #949494;
+      font-weight: 400;
+      text-transform: uppercase;
+    }
+
+    #code h3 {
+      margin: 0;
+    }
+
+    #lhs section {
+      padding: 15px;
+      border-bottom: 1px solid #ccc;
+    }
+
+    .sectionLabel {
+      margin-top: 5px;
+    }
+
+    .knobs {
+      display: grid;
+      grid-template-columns: 70px 1fr;
+      max-width: 400px;
+      row-gap: 15px;
+      column-gap: 10px;
+      align-items: center;
+    }
+
+    input[type='range'] {
+      width: 100px;
+    }
+
+    .knobs label {
+      text-align: right;
+      cursor: pointer;
+    }
+
+    #container {
+      flex: 1;
+    }
+
+    .sliderAndValue {
+      display: flex;
+      align-items: center;
+    }
+
+    .sliderValue {
+      margin-left: 5px;
+    }
+  `;
+
+  private values = new KnobValues();
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.readUrlParams(new URL(document.location.href).searchParams);
+  }
+
+  private setValue<T extends KnobId>(id: T, value: KnobValueType<T>) {
+    this.values.setValue(id, value);
+    this.setUrlParams();
+    this.requestUpdate();
+  }
+
+  private readUrlParams(params: URLSearchParams) {
+    for (const id of knobIds) {
+      let urlValue = params.get(id);
+      if (urlValue === null) {
+        continue;
+      }
+      const knob = knobsById[id];
+      switch (knob.type) {
+        case 'checkbox':
+          this.setValue(knob.id, urlValue === 'y');
+          break;
+        case 'color':
+          this.setValue(knob.id, '#' + urlValue);
+          break;
+        case 'slider':
+          this.setValue(knob.id, Number(urlValue));
+          break;
+        case 'select':
+          this.setValue(knob.id, urlValue as any);
+          break;
+        default:
+          throwUnreachable(knob, `Unexpected knob type ${(knob as Knob).type}`);
+      }
+    }
+  }
+
+  private setUrlParams() {
+    const params = new URLSearchParams();
+    for (const knob of knobs) {
+      let value = this.values.getValue(knob.id);
+      if (value === knob.default) {
+        continue;
+      }
+      switch (knob.type) {
+        case 'checkbox':
+          params.set(knob.id, (value as boolean) ? 'y' : 'n');
+          break;
+        case 'color':
+          params.set(knob.id, (value as string).substring(1));
+          break;
+        case 'slider':
+          params.set(knob.id, String(value as number));
+          break;
+        case 'select':
+          params.set(knob.id, value as string);
+          break;
+        default:
+          throwUnreachable(knob, `Unexpected knob type ${(knob as Knob).type}`);
+      }
+    }
+    history.replaceState(null, '', '?' + params.toString());
+  }
+
+  render() {
+    return html`
+      <style>
+        ${this.cssText}
+      </style>
+
+      <div id="lhs">${this.knobs}</div>
+
+      <div id="rhs">
+        <div
+          id="container"
+          style="background-color:${this.values.getValue('pageBackground')}"
+        >
+          <code-sample
+            theme=${this.values.getValue('theme')}
+            .lineNumbers=${this.values.getValue('lineNumbers')}
+            project-src="./project/project.json"
+          >
+          </code-sample>
+
+          ${this.githubCorner}
+        </div>
+
+        <div id="code">
+          <div>
+            <h3>CSS</h3>
+            <codemirror-editor .value=${this.cssText} type="css" readonly>
+            </codemirror-editor>
+          </div>
+
+          <div>
+            <h3>HTML</h3>
+            <codemirror-editor .value=${this.htmlText} type="html" readonly>
+            </codemirror-editor>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private get knobs() {
+    return knobSectionNames.map(
+      (section) =>
+        html`<section>
+          <h3 class="sectionLabel">${section}</h3>
+          <div class="knobs">
+            ${knobsBySection[section].map((knob) => this.knob(knob))}
+          </div>
+        </section>`
+    );
+  }
+
+  private get htmlText() {
+    return `
+<code-sample${this.htmlTextAttributes}>
+</code-sample>
+`;
+  }
+
+  private get htmlTextAttributes() {
+    const attributes = [];
+    for (const id of knobIds) {
+      const knob: Knob = knobsById[id];
+      if (!knob.htmlAttribute) {
+        continue;
+      }
+      const value = this.values.getValue(id);
+      if (value === knob.default) {
+        continue;
+      }
+      switch (knob.type) {
+        case 'checkbox':
+          if (value) {
+            attributes.push(` ${knob.htmlAttribute}`);
+          }
+          break;
+        default:
+          attributes.push(` ${knob.htmlAttribute}="${value}"`);
+          break;
+      }
+    }
+    return attributes.join('');
+  }
+
+  private get cssText() {
+    const props = [];
+    for (const id of knobIds) {
+      const knob: Knob = knobsById[id];
+      if (!(knob as Knob).cssProperty) {
+        continue;
+      }
+      const value = this.values.getValue(id);
+      let line = `${knob.cssProperty}: ${
+        knob.formatCss ? (knob as any).formatCss(value) : value
+      };`;
+      if (value === knob.default) {
+        line = `/*${line}*/`;
+      } else {
+        line = `  ${line}`;
+      }
+      props.push(line);
+    }
+    return `
+code-sample {
+${props.join('\n')}
+}
+    `;
+  }
+
+  private knob(knob: Knob) {
+    const label = html`<label for=${knob.id}>${knob.label}</label>`;
+    switch (knob.type) {
+      case 'select':
+        return [label, this.selectKnob(knob)];
+      case 'slider':
+        return [label, this.sliderKnob(knob)];
+      case 'color':
+        return [label, this.colorKnob(knob)];
+      case 'checkbox':
+        return [label, this.checkboxKnob(knob)];
+    }
+    return '';
+  }
+
+  private selectKnob(knob: KnobsOfType<'select'>) {
+    const value = this.values.getValue(knob.id);
+    return html`
+      <select
+        id=${knob.id}
+        @input=${(event: Event & {target: HTMLSelectElement}) => {
+          this.setValue(knob.id, event.target.value as any);
+        }}
+      >
+        ${(knob.options as ReadonlyArray<string>).map(
+          (option) =>
+            html`<option value=${option} ?selected=${option === value}>
+              ${option}
+            </option>`
+        )}
+      </select>
+    `;
+  }
+
+  private sliderKnob(knob: KnobsOfType<'slider'>) {
+    const value = this.values.getValue(knob.id);
+    return html`
+      <span class="sliderAndValue">
+        <input
+          id=${knob.id}
+          type="range"
+          min=${knob.min}
+          max=${knob.max}
+          value=${value}
+          @input=${(event: Event & {target: HTMLInputElement}) => {
+            this.setValue(knob.id, Number(event.target.value));
+          }}
+        />
+        <span class="sliderValue"
+          >${knob.formatCss ? knob.formatCss(value) : value}</span
+        >
+      </span>
+    `;
+  }
+
+  private colorKnob(knob: KnobsOfType<'color'>) {
+    let value = this.values.getValue(knob.id);
+    return html`
+      ${'unsetLabel' in knob
+        ? html`
+            <div style="margin-bottom: 5px">
+              <input
+                id=${knob.id + '-unset'}
+                type="checkbox"
+                ?checked=${value === ''}
+                @input=${(event: Event & {target: HTMLInputElement}) => {
+                  value = event.target.checked ? '' : '#ffffff';
+                  this.setValue(knob.id, value);
+                }}
+              />
+              <label for=${knob.id + '-unset'}> ${knob.unsetLabel}</label>
+            </div>
+            <span></span>
+          `
+        : ''}
+      <input
+        id=${knob.id}
+        type="color"
+        .value=${value === '' ? '#ffffff' : String(value)}
+        ?disabled=${value === ''}
+        @input=${(event: Event & {target: HTMLInputElement}) => {
+          this.setValue(knob.id, event.target.value);
+        }}
+      />
+    `;
+  }
+
+  private checkboxKnob(knob: KnobsOfType<'checkbox'>) {
+    let value = this.values.getValue(knob.id);
+    return html`
+      <input
+        id=${knob.id}
+        type="checkbox"
+        ?checked=${value}
+        @change=${(event: Event & {target: HTMLInputElement}) => {
+          this.setValue(knob.id, event.target.checked);
+        }}
+      />
+    `;
+  }
+
+  /**
+   * https://tholman.com/github-corners/
+   */
+  private get githubCorner() {
+    return html`<a
+        href="https://github.com/PolymerLabs/code-sample-editor"
+        class="github-corner"
+        aria-label="View source on GitHub"
+        ><svg
+          width="80"
+          height="80"
+          viewBox="0 0 250 250"
+          style="fill:#00000033; color:#fff; position: absolute; top: 0; border: 0; right: 0;"
+          aria-hidden="true"
+        >
+          <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+          <path
+            d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+            fill="currentColor"
+            style="transform-origin: 130px 106px;"
+            class="octo-arm"
+          ></path>
+          <path
+            d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+            fill="currentColor"
+            class="octo-body"
+          ></path></svg></a
+      ><style>
+        .github-corner:hover .octo-arm {
+          animation: octocat-wave 560ms ease-in-out;
+        }
+        @keyframes octocat-wave {
+          0%,
+          100% {
+            transform: rotate(0);
+          }
+          20%,
+          60% {
+            transform: rotate(-25deg);
+          }
+          40%,
+          80% {
+            transform: rotate(10deg);
+          }
+        }
+        @media (max-width: 500px) {
+          .github-corner:hover .octo-arm {
+            animation: none;
+          }
+          .github-corner .octo-arm {
+            animation: octocat-wave 560ms ease-in-out;
+          }
+        }
+      </style>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'playground-configurator': PlaygroundConfigurator;
+  }
+}
+
+function throwUnreachable(_x: never, msg: string) {
+  throw new Error(msg);
+}

--- a/src/configurator/lib/playground-configurator.ts
+++ b/src/configurator/lib/playground-configurator.ts
@@ -220,7 +220,7 @@ export class PlaygroundConfigurator extends LitElement {
           >
           </code-sample>
 
-          ${this.githubCorner}
+          ${githubCorner}
         </div>
 
         <div id="code">
@@ -409,62 +409,6 @@ ${props.join('\n')}
       />
     `;
   }
-
-  /**
-   * https://tholman.com/github-corners/
-   */
-  private get githubCorner() {
-    return html`<a
-        href="https://github.com/PolymerLabs/code-sample-editor"
-        class="github-corner"
-        aria-label="View source on GitHub"
-        ><svg
-          width="80"
-          height="80"
-          viewBox="0 0 250 250"
-          style="fill:#00000033; color:#fff; position: absolute; top: 0; border: 0; right: 0;"
-          aria-hidden="true"
-        >
-          <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
-          <path
-            d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
-            fill="currentColor"
-            style="transform-origin: 130px 106px;"
-            class="octo-arm"
-          ></path>
-          <path
-            d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
-            fill="currentColor"
-            class="octo-body"
-          ></path></svg></a
-      ><style>
-        .github-corner:hover .octo-arm {
-          animation: octocat-wave 560ms ease-in-out;
-        }
-        @keyframes octocat-wave {
-          0%,
-          100% {
-            transform: rotate(0);
-          }
-          20%,
-          60% {
-            transform: rotate(-25deg);
-          }
-          40%,
-          80% {
-            transform: rotate(10deg);
-          }
-        }
-        @media (max-width: 500px) {
-          .github-corner:hover .octo-arm {
-            animation: none;
-          }
-          .github-corner .octo-arm {
-            animation: octocat-wave 560ms ease-in-out;
-          }
-        }
-      </style>`;
-  }
 }
 
 declare global {
@@ -476,3 +420,57 @@ declare global {
 function throwUnreachable(_x: never, msg: string) {
   throw new Error(msg);
 }
+
+/**
+ * https://tholman.com/github-corners/
+ */
+const githubCorner = html`<a
+    href="https://github.com/PolymerLabs/code-sample-editor"
+    class="github-corner"
+    aria-label="View source on GitHub"
+    ><svg
+      width="80"
+      height="80"
+      viewBox="0 0 250 250"
+      style="fill:#00000033; color:#fff; position: absolute; top: 0; border: 0; right: 0;"
+      aria-hidden="true"
+    >
+      <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+      <path
+        d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+        fill="currentColor"
+        style="transform-origin: 130px 106px;"
+        class="octo-arm"
+      ></path>
+      <path
+        d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+        fill="currentColor"
+        class="octo-body"
+      ></path></svg></a
+  ><style>
+    .github-corner:hover .octo-arm {
+      animation: octocat-wave 560ms ease-in-out;
+    }
+    @keyframes octocat-wave {
+      0%,
+      100% {
+        transform: rotate(0);
+      }
+      20%,
+      60% {
+        transform: rotate(-25deg);
+      }
+      40%,
+      80% {
+        transform: rotate(10deg);
+      }
+    }
+    @media (max-width: 500px) {
+      .github-corner:hover .octo-arm {
+        animation: none;
+      }
+      .github-corner .octo-arm {
+        animation: octocat-wave 560ms ease-in-out;
+      }
+    }
+  </style>`;

--- a/src/lib/code-sample-project.ts
+++ b/src/lib/code-sample-project.ts
@@ -268,7 +268,7 @@ export class CodeSampleProjectElement extends LitElement {
   }
 
   private async _connectServiceWorker(worker: ServiceWorker) {
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       const {port1, port2} = new MessageChannel();
 
       const onMessage = (e: MessageEvent) => {

--- a/src/test/code-sample_test.ts
+++ b/src/test/code-sample_test.ts
@@ -58,7 +58,7 @@ suite('code-sample', () => {
       'code-sample-preview',
       'iframe'
     )) as HTMLIFrameElement;
-    await new Promise((resolve) => {
+    await new Promise<void>((resolve) => {
       const listener = () => {
         iframe.removeEventListener('load', listener);
         resolve();
@@ -68,7 +68,7 @@ suite('code-sample', () => {
     // TODO(aomarks) Chromium and Webkit both fire iframe "load" after the
     // contentDocument has actually loaded, but Firefox fires it before. Why is
     // that? If not for that, we wouldn't need to poll here.
-    await new Promise((resolve) => {
+    await new Promise<void>((resolve) => {
       const check = () => {
         if (iframe.contentDocument?.body?.textContent?.includes(text)) {
           resolve();

--- a/src/test/codemirror-editor_test.ts
+++ b/src/test/codemirror-editor_test.ts
@@ -58,7 +58,7 @@ suite('codemirror-editor', () => {
     editor.value = 'foo';
     container.appendChild(editor);
     await editor.updateComplete;
-    await new Promise((resolve) => {
+    await new Promise<void>((resolve) => {
       editor.addEventListener('change', () => resolve());
       const editorInternals = (editor as unknown) as {
         _codemirror: CodeMirrorEditorElement['_codemirror'];


### PR DESCRIPTION
Automatically deploys to https://polymerlabs.github.io/code-sample-editor/

In retrospect, this basically evolved into a primitive knobs system that's really similar to what storybook does. I would be happy to migrate to an existing storybook framework as a followup, preferably an open-sourced version of @rictic 's internal one. I do like the minimalist presentation and the copy/pasteable HTML/CSS panel here, but those both of those seem like things that could probably be replicated in another system.

Customized example: https://polymerlabs.github.io/code-sample-editor/?theme=monokai&fontFamily=Source+Code+Pro&lineNumbers=y&filePickerBackground=1a1a1a&filePickerForeground=f5f5f5&previewToolbarBackground=dedede&previewToolbarForeground=2b2b2b&borders=n&highlight=f0006c&radius=6&barHeight=46&pageBackground=8c8c8c

![image](https://user-images.githubusercontent.com/48894/96527802-e2a59080-1235-11eb-83fc-e9caf1e7edb6.png)


